### PR TITLE
Add a CLI interface to convert files and directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get -y clean \
 WORKDIR /opt
 ENV PORT 8080
 EXPOSE 8080
-CMD exec java $JAVA_OPTS -jar app.jar
+ENTRYPOINT exec java $JAVA_OPTS -jar app.jar
 
 ## Set the locale
 ENV LANG sv_SE.UTF-8

--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ Anropa endpoints med valfritt verktyg. I utveckling har vi använt curl från gi
 Jenkins pipeline exempel
 [Jenkinsfile](docs/jenkinsfile)
 
+### Via CLI
+Konvertera en specifikationsfil och få DCAT-data till stdout:
+```
+java -jar dcatprocessor.jar -f FIL
+```
+
+Konvertera en katalog med specifikationsfiler och få DCAT-data till stdout:
+```
+java -jar dcatprocessor.jar -d KATALOG
+```
+
 ## Arbetssätt vid lokal utveckling
 
 ### Använda Docker
@@ -161,7 +172,7 @@ För att  köra verktyget direkt från jarfilen öppnar man ett kommandfönster 
 ```
 java -jar <jar-file-name>.jar
 ```
-Detta kör igång verktyget lokalt på datorn. 
+Detta kör igång verktyget lokalt på datorn.
 
 ### Göra anrop till Verktyget
 Kör anrop till rest api via git bash, Postman eller annat verktyg<br>

--- a/src/main/java/se/ams/dcatprocessor/Application.java
+++ b/src/main/java/se/ams/dcatprocessor/Application.java
@@ -17,14 +17,62 @@
 
 package se.ams.dcatprocessor;
 
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import se.ams.dcatprocessor.Manager;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertTrue;
+
 
 @SpringBootApplication
 public class Application {
 
-	public static void main(String[] args) {
-		SpringApplication.run(Application.class, args);
-	}
+    public static void main(String[] args) {
+        if (args.length == 2 && args[0].equals("-f")
+                && (args[1].endsWith(".raml") || args[1].endsWith(".yaml") || args[1].endsWith(".json"))) {
+            convertFile(args[1]);
+        } else if (args.length == 2 && args[0].equals("-d")) {
+            convertDir(args[1]);
+        } else {
+            SpringApplication.run(Application.class, args);
+        }
+    }
+
+
+    public static void convertFile(String filename) {
+        Manager manager = new Manager();
+        Path path = Path.of(filename);
+        MultiValuedMap<String, String> apiSpecMap = new ArrayListValuedHashMap<>();
+        String result;
+
+        try {
+            String content = Files.readString(path);
+            apiSpecMap.put(path.toString(), content);
+            result = manager.createDcat(apiSpecMap);
+            assertTrue(!result.isEmpty());
+            System.out.println(result);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public static void convertDir(String dirname) {
+        Manager manager = new Manager();
+        String result;
+
+        try {
+            result = manager.createDcatFromDirectory(dirname);
+            assertTrue(!result.isEmpty());
+            System.out.println(result);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
 }


### PR DESCRIPTION
This PR contains functionality and documentation for another way to run the DCAT processor.

If the jar file is started with the command line arguments `-f FILE`, the given file will be converted and the result printed to stdout.
If the jar file is started with the command line arguments `-d DIRECTORY`, the files in the given directory will be converted and the result printed to stdout.
