### PR TITLE
Uncomment tests in ManagerTest

### DIFF
--- a/src/test/java/se/ams/dcatprocessor/ManagerTest.java
+++ b/src/test/java/se/ams/dcatprocessor/ManagerTest.java
@@ -291,7 +291,7 @@ public class ManagerTest {
         manager = new Manager();
     }
 
-/*    @Test
+    @Test
     void testValidRaml1() throws Exception {
         File apidefDir = new File("src/test/resources/apidef/raml_1");
 
@@ -369,6 +369,6 @@ public class ManagerTest {
         end = Pattern.quote(end);
         return input.replaceAll("(" + start + ")" + ".*" + "(" + end + ")",
                 (startInclusive ? "" : "$1") + replaceWith + (endInclusive ? "" : "$2"));
-    } */
+    }
     // endregion
 }


### PR DESCRIPTION
# Remove comment around unit tests in ManagerTest

## Description

The code for the unit tests in `ManagerTest.java` were commented out. In this pull request, I remove the comment around the tests because the tests run fine.

Fixes #20

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
