### PR TITLE
Refactor and add ConversionConfig class as argument to createDcat

### DIFF
--- a/src/main/java/se/ams/dcatprocessor/Application.java
+++ b/src/main/java/se/ams/dcatprocessor/Application.java
@@ -46,14 +46,9 @@ public class Application {
 
     public static void convertFile(String filename) {
         Manager manager = new Manager();
-        Path path = Path.of(filename);
-        MultiValuedMap<String, String> apiSpecMap = new ArrayListValuedHashMap<>();
-        String result;
-
         try {
-            String content = Files.readString(path);
-            apiSpecMap.put(path.toString(), content);
-            result = manager.createDcat(apiSpecMap);
+            ConversionConfig config = ConversionConfig.fromFile(Path.of(filename));
+            String result = manager.createDcat(config);
             assertTrue(!result.isEmpty());
             System.out.println(result);
         } catch (Exception e) {

--- a/src/main/java/se/ams/dcatprocessor/ConversionConfig.java
+++ b/src/main/java/se/ams/dcatprocessor/ConversionConfig.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of dcat-ap-se-processor.
+ *
+ * dcat-ap-se-processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dcat-ap-se-processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dcat-ap-se-processor.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package se.ams.dcatprocessor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Scanner;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
+import org.springframework.web.multipart.MultipartFile;
+
+
+public class ConversionConfig {
+    private Path workDir;
+    private MultiValuedMap<String, String> apiSpecMap;
+    
+    public static Path getDefaultWorkDir() {
+        return Path.of(System.getProperty("user.dir"));
+    }
+    
+    public boolean isValid() {
+        return apiSpecMap != null && !apiSpecMap.isEmpty();
+    }
+
+    private ConversionConfig(MultiValuedMap<String, String> apiSpecMap, Path workDir) {
+        this.apiSpecMap = apiSpecMap;
+        this.workDir = workDir;
+    }
+
+    private ConversionConfig copy() {
+        return new ConversionConfig(apiSpecMap, workDir);
+    }
+
+    public ConversionConfig withWorkDir(Path workDir) {
+        ConversionConfig dst = copy();
+        dst.workDir = workDir;
+        return dst;
+    }
+
+    public MultiValuedMap<String, String> getApiSpecMap() {
+        assert(isValid());
+        return apiSpecMap;
+    }
+
+    public static ConversionConfig fromApiSpecMap(MultiValuedMap<String, String> apiSpecMap) {
+        return new ConversionConfig(apiSpecMap, getDefaultWorkDir());
+    }
+
+    public static ConversionConfig fromKeyValue(String key, String value) {
+        MultiValuedMap<String, String> apiSpecMap = new ArrayListValuedHashMap<>();
+        apiSpecMap.put(key, value);
+        return ConversionConfig.fromApiSpecMap(apiSpecMap);
+    }
+
+    public static ConversionConfig fromFile(Path path) throws IOException {
+        return ConversionConfig.fromKeyValue(path.toString(), Files.readString(path));
+    }
+    
+    public static ConversionConfig fromDirectory(Path dir) throws IOException {
+        MultiValuedMap<String, String> apiSpecMap = new ArrayListValuedHashMap<>();
+
+        // returns pathnames for files and directory
+        File[] files = dir.toFile().listFiles((dir1, name) -> name.endsWith(".raml") || name.endsWith(".yaml") || name.endsWith(".json"));
+
+        // for each file in file array
+        if (files != null && files.length > 0) {
+            for (File file : files) {
+                Path path = Path.of(String.valueOf(file));
+                try {
+                    String content = Files.readString(path);
+                    apiSpecMap.put(path.toString(), content);
+                } finally {
+                }
+            }
+        }
+        return ConversionConfig.fromApiSpecMap(apiSpecMap);
+    }
+
+    public static ConversionConfig fromList(List<MultipartFile> apiFiles, List<Result> outResults) {
+        MultiValuedMap<String, String> apiSpecMap = new ArrayListValuedHashMap<>();
+        for (MultipartFile apiFile : apiFiles) {
+            if (!apiFile.isEmpty()) {
+                String apiSpecificationFromFile;
+                Scanner scanner;
+                try {
+                    scanner = new Scanner(apiFile.getInputStream(), StandardCharsets.UTF_8.name());
+                    apiSpecificationFromFile = scanner.useDelimiter("\\A").next();
+                    scanner.close();
+                    apiSpecMap.put(apiFile.getOriginalFilename(), apiSpecificationFromFile);
+                } catch (Exception e) {        //Catch and show processing errors in web-gui
+                    outResults.add(new Result(null, e.getMessage()));
+                    e.printStackTrace();
+                }
+            }
+        }
+        return ConversionConfig.fromApiSpecMap(apiSpecMap);
+    }
+
+    public Path getWorkDir() {
+        return workDir;
+    }
+}

--- a/src/main/java/se/ams/dcatprocessor/parser/ApiDefinitionParser.java
+++ b/src/main/java/se/ams/dcatprocessor/parser/ApiDefinitionParser.java
@@ -33,12 +33,18 @@ import java.io.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.nio.file.Path;
 
 public class ApiDefinitionParser {
 
     private static Logger logger = LoggerFactory.getLogger(ApiDefinitionParser.class);
 
-    public static JSONObject getApiJsonString(String fileString) throws IOException, ParseException {
+    // TODO: Do we need to provide a method with this signature for the sake of not breaking the API? Or will people adapt?
+    //
+    // public static JSONObject getApiJsonString(String fileString) throws IOException, ParseException
+    
+    public static JSONObject getApiJsonString(
+        String fileString, Path outJsonFile) throws IOException, ParseException {
         JSONParser parser = new JSONParser();
         Stream<String> lines;
         String apiJsonString = "";
@@ -47,9 +53,9 @@ public class ApiDefinitionParser {
         String apiLine1 = lines.limit(1).collect(Collectors.joining("\n"));
 
         if (apiLine1.contains("openapi")) {
-            apiJsonString = getFileApiYamlRaml(fileString);
+            apiJsonString = getFileApiYamlRaml(fileString, outJsonFile);
         } else if (apiLine1.contains("RAML")) {
-            apiJsonString = getFileApiYamlRaml(fileString);
+            apiJsonString = getFileApiYamlRaml(fileString, outJsonFile);
         } else if (apiLine1.contains("{")){
             apiJsonString = fileString;
         }
@@ -64,8 +70,8 @@ public class ApiDefinitionParser {
         return jsonObjectFile;
     }
 
-    private static String getFileApiYamlRaml(String apiSpec) throws IOException {
-        FileOutputStream output = new FileOutputStream("output.json");
+    private static String getFileApiYamlRaml(String apiSpec, Path outJsonFile) throws IOException {
+        FileOutputStream output = new FileOutputStream(outJsonFile.toFile());
         JsonFactory factory = new JsonFactory();
         JsonGenerator generator = factory.createGenerator(output, JsonEncoding.UTF8);
 
@@ -78,7 +84,7 @@ public class ApiDefinitionParser {
             output.close();
 
             JSONParser jsonParser = new JSONParser();
-            FileReader reader = new FileReader("output.json");
+            FileReader reader = new FileReader(outJsonFile.toFile());
 
             //Read JSON file
             Object obj = jsonParser.parse(reader);

--- a/src/test/java/se/ams/dcatprocessor/ConversionConfigTest.java
+++ b/src/test/java/se/ams/dcatprocessor/ConversionConfigTest.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of dcat-ap-se-processor.
+ *
+ * dcat-ap-se-processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dcat-ap-se-processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dcat-ap-se-processor.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package se.ams.dcatprocessor;
+
+import org.junit.jupiter.api.Test;
+import org.apache.commons.collections4.MultiValuedMap;
+import se.ams.dcatprocessor.rdf.DcatException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.ArrayList;
+import org.springframework.mock.web.MockMultipartFile;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public class ConversionConfigTest {
+    
+    @Test
+    void testFromKeyValue() throws Exception {
+        ConversionConfig cfg = ConversionConfig.fromKeyValue("k119", "the spec goes here");
+        assertEquals(ConversionConfig.getDefaultWorkDir(), cfg.getWorkDir());
+        assertTrue(cfg.isValid());
+        MultiValuedMap m = cfg.getApiSpecMap();
+        assertEquals(1, m.size());
+        assertEquals(List.of("the spec goes here"), m.get("k119"));
+        checkWorkDirChangeIsWorking(cfg);
+    }
+    
+    @Test
+    void testFromFileAndDirectory() throws Exception {
+        ConversionConfig[] configsToTest = new ConversionConfig[]{
+            ConversionConfig.fromFile(Path.of("src/test/resources/apidef/json_oas/obl_rek_oas.json")),
+            ConversionConfig.fromDirectory(Path.of("src/test/resources/apidef/json_oas")),
+        };
+        for (ConversionConfig cfg: configsToTest) {
+            checkJsonOasContents(cfg);
+            checkWorkDirChangeIsWorking(cfg);
+        }        
+    }
+
+    @Test
+    void testMultipartFile() throws Exception {
+        String filename = "src/test/resources/apidef/json_oas/obl_rek_oas.json";
+        Path srcPath = Path.of(filename);
+        byte[] bytes = Files.readAllBytes(srcPath);
+        MockMultipartFile file = new MockMultipartFile(filename, filename, StandardCharsets.UTF_8.name(), bytes);
+        
+        ArrayList<Result> results = new ArrayList<Result>();
+        ConversionConfig cfg = ConversionConfig.fromList(List.of(file), results);
+        checkJsonOasContents(cfg);
+        
+        // If no exceptions are thrown, then nothing is pushed to results.
+        assertTrue(results.isEmpty());
+
+        checkWorkDirChangeIsWorking(cfg);        
+    }
+
+    // Common checks for the unit tests
+    private ConversionConfig checkWorkDirChangeIsWorking(ConversionConfig src) throws Exception {
+        Path tempDir = Files.createTempDirectory("DCAT_workdir");
+        ConversionConfig dst = src.withWorkDir(tempDir);
+        assertEquals(tempDir, dst.getWorkDir());
+        assertEquals(ConversionConfig.getDefaultWorkDir(), src.getWorkDir());
+        return dst;        
+    }
+
+    private void checkJsonOasContents(ConversionConfig cfg) {
+        assertTrue(cfg.isValid());
+        MultiValuedMap m = cfg.getApiSpecMap();
+        assertEquals(1, m.size());
+        Collection<String> coll = m.get("src/test/resources/apidef/json_oas/obl_rek_oas.json");
+        assertEquals(1, coll.size());
+        String first = coll.iterator().next();
+        assertTrue(first.startsWith("{"));
+    }
+}

--- a/src/test/java/se/ams/dcatprocessor/ManagerTest.java
+++ b/src/test/java/se/ams/dcatprocessor/ManagerTest.java
@@ -19,8 +19,11 @@ package se.ams.dcatprocessor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 import org.apache.commons.collections4.MultiValuedMap;
@@ -289,6 +292,40 @@ public class ManagerTest {
     @BeforeEach
     void setup() {
         manager = new Manager();
+    }
+
+    void checkRdfResult(String result, String innerStringToLookFor) {
+        assertTrue(!result.isEmpty());
+        int a = result.indexOf("<rdf:RDF");
+        int b = result.indexOf(innerStringToLookFor);
+        int c = result.indexOf("</rdf:RDF>");
+        assertTrue(0 < a);
+        assertTrue(a < b);
+        assertTrue(b < c);
+    }
+
+    @Test
+    void testJsonCustomWorkDir() throws Exception {
+        Path tempDir = Files.createTempDirectory("testJsonCustomWorkDir");
+        Path srcPath = Path.of("src/test/resources/apidef/json_oas/obl_rek_oas.json");
+        ConversionConfig config = ConversionConfig.fromFile(srcPath).withWorkDir(tempDir);
+        String result = manager.createDcat(config);
+        checkRdfResult(result, "Redpill Linpro AB Catalog");
+        
+        assertTrue(Files.exists(tempDir.resolve("dcat.rdf")));
+        assertFalse(Files.exists(tempDir.resolve("output.json")));
+    }
+
+    @Test
+    void testRamlCustomWorkDir() throws Exception {
+        Path tempDir = Files.createTempDirectory("testRamlCustomWorkDir");        
+        Path srcPath = Path.of("src/test/resources/apidef/raml_1");
+        ConversionConfig config = ConversionConfig.fromDirectory(srcPath).withWorkDir(tempDir);
+        String result = manager.createDcat(config);
+        checkRdfResult(result, "Redpill Linpro AB Catalog");
+
+        assertTrue(Files.exists(tempDir.resolve("dcat.rdf")));
+        assertTrue(Files.exists(tempDir.resolve("output.json")));
     }
 
 /*    @Test

--- a/src/test/java/se/ams/dcatprocessor/parser/ApiDefinitionParserTest.java
+++ b/src/test/java/se/ams/dcatprocessor/parser/ApiDefinitionParserTest.java
@@ -20,11 +20,16 @@ package se.ams.dcatprocessor.parser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import se.ams.dcatprocessor.rdf.DcatException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class ApiDefinitionParserTest {
     private static ApiDefinitionParser parser;
+    private static Path tempDir;
 
     private static String ramlApi = "#%RAML 1.0\n"
             + "title: Annotation exempel api\n"
@@ -191,16 +196,19 @@ public class ApiDefinitionParserTest {
     private static String ramlResult = "{\"(dcat-dataset 1)\":{\"title-sv\":\"Datamängd 1\",\"about\":\"https:\\/\\/www.example.se\\/result.rdf#dataset1\",\"description\":\"Exempel beskrivning 1\",\"publisher\":{\"name\":\"Redpill Linpro AB 1\"}},\"dcat-dataservice\":{\"properties\":{\"contactPoint\":{\"landingPage\":\"string\",\"adress\":\"string\",\"type\":\"string\",\"license\":\"string\",\"phone\":\"string\",\"name\":\"string\",\"theme\":\"string\",\"conformsTo\":\"string\",\"accessRights\":\"string\",\"page\":\"string\",\"keyword\":\"string\",\"servesDataset\":\"string\",\"email\":\"string\"},\"endpointURL\":\"string\",\"description\":\"string\",\"publisher\":{\"name\":\"string\",\"type\":\"string\",\"mbox\":\"string\",\"homepage\":\"string\"},\"title\":\"string\",\"endpointDescription\":\"string\"}},\"description\":\"Annotation exempel api är ett påhittat api som använder sig av annotations för att skapa metadata för DCAT-AP-SE.\",\"dcat-dataset\":{\"properties\":{\"creator\":\"string\",\"contactPoint\":{\"phone\":\"string\",\"name\":\"string\",\"adress\":\"string\",\"type\":\"string\",\"email\":\"string\"},\"description\":\"string\",\"publisher\":{\"name\":\"string\",\"type\":\"string\",\"mbox\":\"string\",\"homepage\":\"string\"},\"location\":{\"centroid\":\"string\",\"bbox\":\"string\",\"geometry\":\"string\"},\"title\":\"string\",\"distribution\":{\"byteSize\":\"string\",\"accessURL\":\"string\",\"downloadURL\":\"string\",\"description\":\"string\",\"language\":\"string\",\"availability\":\"string\",\"title\":\"string\",\"temporalResolution\":\"string\",\"accessService\":\"string\",\"spatialResolutionInMeters\":\"string\",\"rights\":\"string\",\"checksum\":\"string\",\"modified\":\"string\",\"theme\":\"string\",\"issued\":\"string\",\"keyword\":\"string\",\"identifier\":\"string\",\"adms\":\"string\",\"landingPage\":\"string\",\"format\":\"string\",\"license\":\"string\",\"page\":\"string\",\"conformsTo\":\"string\",\"belongsTo\":\"string\",\"status\":\"string\"},\"qualifiedAttribution\":\"string\",\"temporal\":{\"offers\":\"string\",\"endDate\":\"string\",\"hasVersion\":\"string\",\"versionInfo\":\"string\",\"source\":\"string\",\"relation\":\"string\",\"isReferencedBy\":\"string\",\"provenance\":\"string\",\"temporalResolution\":\"string\",\"spatialResolutionInMeters\":\"string\",\"qualifiedRelation\":\"string\",\"accrualPeriodicity\":\"string\",\"versionNotes\":\"string\",\"accessRights\":\"string\",\"isVersionOf\":\"string\",\"page\":\"string\",\"startDate\":\"string\"}}},\"title\":\"Annotation exempel api\",\"version\":\"1.0.0\",\"annotationTypes\":null,\"dcat-catalog\":{\"properties\":{\"themeTaxonomy\":\"string\",\"hasPart\":\"string\",\"about\":\"string\",\"description\":\"string\",\"language\":\"string\",\"title\":\"string\",\"isPartOf\":\"string\",\"license\":\"string\",\"rights\":\"string\",\"publisher\":{\"name\":\"string\",\"type\":\"string\",\"mbox\":\"string\",\"homepage\":\"string\"},\"modified\":\"string\",\"location\":{\"centroid\":\"string\",\"bbox\":\"string\",\"geometry\":\"string\"},\"issued\":\"string\",\"homepage\":\"string\"}},\"(dcat-catalog)\":{\"title-sv\":\"Annotation exempel RAML 1.0\",\"license\":\"https:\\/\\/www.apache.org\\/licenses\\/LICENSE-2.0\",\"title-en\":\"Annotation example RAML 1.0\",\"about\":\"www.af.se\",\"description\":\"Annotation exempel från arbetsförmedlingen\",\"publisher\":{\"name\":\"Redpill Linpro AB Catalog\"},\"dataset\":\"https:\\/\\/www.example.se\\/result.rdf#dataset1\"}}";
     private static String jsonresult = "{\"dcat-dataset\":{\"title-sv\":\"Datamängd 1\",\"about\":\"https:\\/\\/www.example.se\\/result.rdf#dataset1\",\"publisher\":{\"about\":\"https:\\/\\/www.example.se\\/result.rdf#publisher\",\"name\":\"Redpill Linpro AB 1\"},\"description-sv\":\"Exempel beskrivning 1\"},\"dcat-catalog\":{\"title-sv\":\"Annotation exempel RAML 1.0\",\"license\":\"https:\\/\\/www.apache.org\\/licenses\\/LICENSE-2.0\",\"title-en\":\"Annotation example RAML 1.0\",\"about\":\"https:\\/\\/www.af.se\",\"publisher\":{\"about\":\"https:\\/\\/www.example.se\\/result.rdf#publisher\",\"name\":\"Redpill Linpro AB Catalog\"},\"description-sv\":\"Annotation exempel från arbetsförmedlingen\"}}";
     @BeforeEach
-    void setup() {
+    void setup() throws Exception {
         parser = new ApiDefinitionParser();
+        tempDir = Files.createTempDirectory("ApiDefinitionParserTest");
     }
 
     //TODO: Fixa så att testet funkar
     @Test
     void testMandatoryRamlApi() throws Exception {
         try {
-            String result = parser.getApiJsonString(ramlApi).toString();
+            Path outPath = tempDir.resolve("output0.json");
+            String result = parser.getApiJsonString(ramlApi, outPath).toString();
             assertEquals(result, ramlResult);
+            assertTrue(Files.exists(outPath));
         } catch (DcatException e) {
 
         }
@@ -209,8 +217,12 @@ public class ApiDefinitionParserTest {
     @Test
     void testMandatoryJsonApi() throws Exception {
         try {
-            String result = parser.getApiJsonString(jsonApi).toString();
+            Path outPath = tempDir.resolve("output1.json");
+            String result = parser.getApiJsonString(jsonApi, outPath).toString();
             assertEquals(result, jsonresult);
+
+            // The outFile is only produced for non-json data.
+            assertFalse(Files.exists(outPath));
         } catch (DcatException e) {
 
         }


### PR DESCRIPTION
# Refactor and add ConversionConfig class as argument to createDcat

## Description

This pull request addresses issue #22 and makes it possible to specify a *working directory* where files are produced when calling the method `Manager.createDcat`. As part of that, I made the following changes:

* Add a new class `ConversionConfig` that contains (1) the `apiSpecMap` and (2) the `workDir` working directory. This class wraps the data consumed by `Manager.createDcat`.
* Move some of the logic from the methods `Manager.createFromFile` and `Manager.createFromDirectory` to this new `ConversionConfig` class as methods `fromDirectory` and `fromFile`.
* Make the `Manager.createDcat` implementation take a `ConversionConfig` instead of a `MultiValueMap`.
* Output files to the workDir of the `ConversionConfig`.
* Fix a bug in the `Manager.createFromList` method where the exception message will be pushed twice to `results` if `createDcat` throws an exception. This bug was fixed as a consequence of the refactoring.

Fixes #22 

## Checklist

- [ ] My contributions and commit messages follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] The Pull Request has an informative and human-readable title
- [ ] Changes are limited to a single goal (avoid scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [ ] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
