### PR TITLE
Refactor ApiDefinitionParser to fix issue #23

### DIFF
--- a/src/test/java/se/ams/dcatprocessor/parser/ApiDefinitionParserTest.java
+++ b/src/test/java/se/ams/dcatprocessor/parser/ApiDefinitionParserTest.java
@@ -195,24 +195,24 @@ public class ApiDefinitionParserTest {
         parser = new ApiDefinitionParser();
     }
 
-    //TODO: Fixa så att testet funkar
+    // Helper method
+    void checkParse(String input, ApiDefinitionParser.ApiSpecSyntax expectedSyntax, String expectedOutput) throws Exception {
+        assertEquals(expectedSyntax, parser.guessSyntax(input));
+        assertEquals(expectedOutput, parser.getApiJsonString(input).toString());
+    }
+    
     @Test
     void testMandatoryRamlApi() throws Exception {
-        try {
-            String result = parser.getApiJsonString(ramlApi).toString();
-            assertEquals(result, ramlResult);
-        } catch (DcatException e) {
-
-        }
+        checkParse(ramlApi, ApiDefinitionParser.ApiSpecSyntax.YamlRaml, ramlResult);
     }
 
     @Test
     void testMandatoryJsonApi() throws Exception {
-        try {
-            String result = parser.getApiJsonString(jsonApi).toString();
-            assertEquals(result, jsonresult);
-        } catch (DcatException e) {
+        checkParse(jsonApi, ApiDefinitionParser.ApiSpecSyntax.Json, jsonresult);
+    }
 
-        }
+    @Test
+    void testMandatoryJsonApiCompactFormatting() throws Exception {
+        checkParse(jsonApi.replace("\n", ""), ApiDefinitionParser.ApiSpecSyntax.Json, jsonresult);
     }
 }


### PR DESCRIPTION
# Refactor ApiDefinitionParser to fix issue #23

## Description

This PR addresses the issue #23 where a compact json string is incorrectly parsed as Yaml/Raml. To address that bug, I put the logic to identify the syntax in the method `guessSyntax` and I also unit test that method to make sure that the bug is actually fixed. Along with this, I also restructured the code a bit in `ApiDefinitionParser`.

Fixes #23 

## Checklist

- [ ] My contributions and commit messages follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] The Pull Request has an informative and human-readable title
- [ ] Changes are limited to a single goal (avoid scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [ ] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
