### PR TITLE
ci: fix chainguard image base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,18 +11,17 @@ RUN ./mvnw clean package spring-boot:repackage
 
 
 # Note: The default non root chainguard user is 65532
-FROM cgr.dev/chainguard/jdk:openjdk-jre-11-20221109
+FROM cgr.dev/chainguard/jdk:latest
 
 USER root
-RUN mkdir -p /opt/.logs \
-    && mkdir -p /apidef
-RUN chown -R 65532:65532 /opt/
+RUN mkdir -p /app/.logs \
+  && mkdir -p /apidef
+RUN chown -R 65532:65532 /app/
 USER 65532
-COPY --from=build /build/target/dcat-ap-processor-0.0.2-SNAPSHOT.jar /opt/app.jar
+COPY --from=build /build/target/dcat-ap-processor-0.0.2-SNAPSHOT.jar /app/app.jar
 
 
 ENV JDK_JAVA_OPTIONS -Duser.language=sv-SE -Duser.region=SE -Duser.timezone=Europe/Stockholm
-WORKDIR /opt
 ENV PORT 8080
 EXPOSE 8080
-CMD ["-jar","app.jar"]
+CMD ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
A minimalist approach to fix the changes from chainguard regarding usage of the their jdk images.
Tested quickly locally, and seemed to build and run fine.

(Note: @fredriknordlander @jonassodergren It really itched in my fingers to add java 17, clean up the workflow, add a jar build, bump and test dependecies and so on. But kept it as small I could due to time restrictions. However I might add some further small and seperated PR's to this project. Maybe a jdk 17 base could be a good start, as that allows for bumps of spring etc). Do you want to leave all that fun to other devs, or ,otherwise a few quality related PR's might be coming when I get the time).


Fixes #26

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
