### PR TITLE
Feature/46 refaktorisering part 2

### DIFF
--- a/src/main/java/se/ams/dcatprocessor/Application.java
+++ b/src/main/java/se/ams/dcatprocessor/Application.java
@@ -21,7 +21,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import se.ams.dcatprocessor.util.CliFlags;
+import se.ams.dcatprocessor.cli.CliFlags;
 
 import java.util.Arrays;
 

--- a/src/main/java/se/ams/dcatprocessor/cli/CliFlags.java
+++ b/src/main/java/se/ams/dcatprocessor/cli/CliFlags.java
@@ -1,4 +1,4 @@
-package se.ams.dcatprocessor.util;
+package se.ams.dcatprocessor.cli;
 
 import java.util.List;
 

--- a/src/main/java/se/ams/dcatprocessor/cli/CliRunner.java
+++ b/src/main/java/se/ams/dcatprocessor/cli/CliRunner.java
@@ -15,7 +15,7 @@
  * along with dcat-ap-se-processor.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package se.ams.dcatprocessor;
+package se.ams.dcatprocessor.cli;
 
 import java.util.List;
 import java.util.stream.IntStream;
@@ -27,7 +27,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
-import se.ams.dcatprocessor.util.CliFlags;
+import se.ams.dcatprocessor.processor.Manager;
 
 @Component
 public class CliRunner implements ApplicationRunner{

--- a/src/main/java/se/ams/dcatprocessor/controller/PreprocessorController.java
+++ b/src/main/java/se/ams/dcatprocessor/controller/PreprocessorController.java
@@ -15,7 +15,8 @@
  * along with dcat-ap-se-processor.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package se.ams.dcatprocessor;
+package se.ams.dcatprocessor.controller;
+import se.ams.dcatprocessor.processor.Manager;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -103,33 +104,25 @@ class PreprocessorController {
 			Manager manager = managerProvider.getObject();
 			String result = "";
 
-			/**
-			 * Generate DCAT-AP-SE from files
-			 */
+			// Generate DCAT-AP-SE from files
 			if(apiSpecification.isEmpty() && !apiFiles.isEmpty()) {
-
 				results = manager.createFromList(apiFiles,model);
-
-				/**
-				 * Generate DCAT-AP-SE from string
-				 */
+		
+			// Generate DCAT-AP-SE from string
 			} else if(!apiSpecification.isEmpty()){
-
 				try {
 					apiSpecMap.put("apifile", apiSpecification);
 					result = manager.createDcat(apiSpecMap);
-				} catch (Exception e) {			//Catch and show processing errors in web-gui
+				
+				//Catch and show processing errors in web-gui
+				} catch (Exception e) {
 					result = e.getMessage();
-					results.add(new Result(null, result));
 					e.printStackTrace();
 				}
-				results.add(new Result(null, result));
+				results.add(new Result(result));
 			}
 			model.addAttribute("results", results);
 		}
 		return "index";
 	}
-	
-	
 }
-

--- a/src/main/java/se/ams/dcatprocessor/controller/Result.java
+++ b/src/main/java/se/ams/dcatprocessor/controller/Result.java
@@ -15,17 +15,17 @@
  * along with dcat-ap-se-processor.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package se.ams.dcatprocessor;
+package se.ams.dcatprocessor.controller;
 
-class Result {
-    private String description;
+public class Result {
+    private String result;
 
-    public Result(Object object, String trim) {
-		description = trim;
+    public Result(String result) {
+		this.result = result;
 	}
 
 	@Override
     public String toString() {
-        return description;
+        return result;
     }
 }

--- a/src/main/java/se/ams/dcatprocessor/converter/Converter.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/Converter.java
@@ -27,11 +27,11 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class Converter {
     Catalog catalog = new Catalog();
     FileStorage fileHandler = new FileStorage();
     JSONObject jsonObjectMandatoryDcat;
+    JSONObject jsonLanguageFile;
     JSONObject orgConvert;
     public static List<String> errors = new ArrayList<>();
 
@@ -57,8 +57,7 @@ public class Converter {
     /*
      * Finds and sets correct converterfile and mandatoryfile depending on if it is catalog or other file */
     void setConvertAndMandatoryFile(String uriToDirectory) throws IOException {
-        String convertFile;
-        convertFile = getFileString(uriToDirectory + ConverterHelpClass.convertFileName);
+        String convertFile = getFileString(uriToDirectory + ConverterHelpClass.convertFileName);
         orgConvert = new JSONObject(convertFile);
 
         String mandatoryFile = getFileString(uriToDirectory + ConverterHelpClass.mandatoryFileName);
@@ -73,20 +72,19 @@ public class Converter {
     /*
      * Finds and sets correct supportiveFile to create correct values for some tags */
     JSONObject getSupportiveFile(String key, String subCat) throws IOException {
-        JSONObject jsonSupportiveDcat = null;
+        String resolvedKey = null;
+        String compositeKey = subCat + "-" + key;
 
         if (ConverterHelpClass.supportiveFile.containsKey(key)) {
-            String fileName = ConverterHelpClass.uriToDcatSupportive + ConverterHelpClass.supportiveFile.get(key);
-            String supportiveFile;
-            supportiveFile = getFileString(fileName);
-            jsonSupportiveDcat = new JSONObject(supportiveFile);
-
-        } else if (ConverterHelpClass.supportiveFile.containsKey(subCat + "-" + key)) {
-            String fileName = ConverterHelpClass.uriToDcatSupportive + ConverterHelpClass.supportiveFile.get(subCat + "-" + key);
-            String supportiveFile = getFileString(fileName);
-            jsonSupportiveDcat = new JSONObject(supportiveFile);
+            resolvedKey = key;
+        } else if (ConverterHelpClass.supportiveFile.containsKey(compositeKey)) {
+            resolvedKey = compositeKey;
+        } else {
+            return null;
         }
-        return jsonSupportiveDcat;
+
+        String fileName = ConverterHelpClass.uriToDcatSupportive + ConverterHelpClass.supportiveFile.get(resolvedKey);
+        return new JSONObject(getFileString(fileName));
     }
 
     /*
@@ -98,51 +96,72 @@ public class Converter {
         dataObj.about = value;
     }
 
-    boolean loopLanguage(JSONObject file, String AnnotationName, Optional<String> subCat, Optional<DataClass> dataClass, String key) throws IOException {
+    JSONObject getOrLoadLanguageFile() throws IOException {
+        if (jsonLanguageFile == null) {
+            jsonLanguageFile = new JSONObject(getFileString(ConverterHelpClass.uriToLanguageDcat));
+        }
+        return jsonLanguageFile;
+    }
+
+    boolean addLanguageValues(JSONObject file, String annotationName, Optional<String> subCat, Optional<DataClass> dataClass, String key) throws IOException {
         boolean hasLanguage = false;
+        JSONObject languageFile = getOrLoadLanguageFile();
 
-        String fileName = ConverterHelpClass.uriToLanguageDcat;
-        String languageFile;
-        languageFile = getFileString(fileName);
-        JSONObject jsonObjectLanguageDcat = new JSONObject(languageFile);
+        for(String langKey : languageFile.keySet()){
+            String keyInLanguage = languageFile.getJSONObject(langKey).getString(ConverterHelpClass.toDcatString);
+            String fieldName = annotationName + "-" + keyInLanguage;
+            
+            if (!file.has(fieldName)) continue;
+            
+            String value = (String) file.get(fieldName);
+            String urlLanguage = languageFile.getJSONObject(langKey).getString("url");
 
-        Object[] languageKeys = jsonObjectLanguageDcat.keySet().toArray();
-        Iterator<?> keysInLanguageFile = Arrays.stream(languageKeys).iterator();
-
-        while (keysInLanguageFile.hasNext()) {
-            Object keyTest = keysInLanguageFile.next();
-
-            String keyInLanguage = jsonObjectLanguageDcat.getJSONObject((String) keyTest).getString(ConverterHelpClass.toDcatString);
-            String urlLanguage = jsonObjectLanguageDcat.getJSONObject((String) keyTest).getString("url");
-
-            if (file.has(AnnotationName + "-" + keyInLanguage)) {
-                String value = (String) file.get(AnnotationName + "-" + keyInLanguage);
-                String[] splitValue = value.split(";");
-                for (String s : splitValue) {
-                    if (subCat.isPresent()) {
-                        if (key.equals(DCTERMS.PROVENANCE.getLocalName())) {
-                            DataClass provenance = new DataClass();
-                            provenance.dcData.put("dcterms:description", keyInLanguage + "¤" + s);
-                            if (dataClass.isPresent()) ((DataSet)dataClass.get()).provenances.add(provenance);
-                        }
-                        else {
-                            dataClass.ifPresent(aClass -> aClass.dcData.put(key, keyInLanguage + "¤" + s));
-                        }
-                        if (subCat.get().equals(DCAT.DATASET.getLocalName()) || subCat.get().equals(DCAT.DISTRIBUTION.getLocalName()) || subCat.get().equals(DCAT.CATALOG.getLocalName())) {
-                            if (dataClass.isPresent()) {
-                                if (!((dataClass.get().dcData.get(ConverterHelpClass.languages)).contains(urlLanguage))) {
-                                    dataClass.get().dcData.put(ConverterHelpClass.languages, urlLanguage);
-                                }
-                            }
-                        }
-                    } else {
-                        catalog.dcData.put(key + "-" + keyInLanguage, value);
-                    }
-                }
-                hasLanguage = true;
+            for (String s : value.split(";")) {
+                applyLanguageValue(subCat, key, keyInLanguage, dataClass, s, urlLanguage);
             }
+            hasLanguage = true;        
         }
         return hasLanguage;
+    }
+
+    private void applyLanguageValue(Optional<String> subCat, String key, String keyInLanguage, Optional<DataClass> optionalDataClass, String value, String urlLanguage){  
+        // Without subCat, write directly to catalog with language suffix
+        if (subCat.isEmpty()) {
+            catalog.dcData.put(key + "-" + keyInLanguage, value);
+            return;
+        }
+        
+        if(subCat.isPresent()){
+
+            if (optionalDataClass.isEmpty()) return;
+
+            DataClass dataClass = optionalDataClass.get();
+            String combinedValue = keyInLanguage + "¤" + value;
+
+            // Provenance is a special case that requires its own DataClass entry
+            if (key.equals(DCTERMS.PROVENANCE.getLocalName())) {
+                DataClass provenance = new DataClass();
+                provenance.dcData.put("dcterms:description", combinedValue);
+
+                if (dataClass instanceof DataSet dataSet) {
+                    dataSet.provenances.add(provenance);
+                }
+            }
+            // Add value to dataClass
+            else {
+                dataClass.dcData.put(key, combinedValue);
+            }
+            String subCatValue = subCat.get();
+            if (subCatValue.equals(DCAT.DATASET.getLocalName()) || subCatValue.equals(DCAT.DISTRIBUTION.getLocalName()) || subCatValue.equals(DCAT.CATALOG.getLocalName())) {
+
+                if (!((dataClass.dcData.get(ConverterHelpClass.languages)).contains(urlLanguage))) {
+                    dataClass.dcData.put(ConverterHelpClass.languages, urlLanguage);
+                }
+            }
+        }
+        else{
+            catalog.dcData.put(key + "-" + keyInLanguage, value);
+        }
     }
 
     /*
@@ -226,18 +245,22 @@ public class Converter {
         }
     }
 
-    void loopData(JSONObject file, String key, String AnnotationName, String newKey, Optional<DataClass> preData, Optional<DataClass> preDist) throws Exception {
+    void convertNestedObject(JSONObject file, String key, String annotationName, String newKey, Optional<DataClass> preData, Optional<DataClass> preDist) throws Exception {
+        JSONObject subToConvert = (JSONObject) orgConvert.get(key);
+        subToConvert.remove(ConverterHelpClass.toDcatMandatoryString);
+        
+        if (subToConvert.keySet().size() > 0) {
+            JSONObject subJsonFile = ((JSONObject) file.get(annotationName));
+            processToDcat(subToConvert, subJsonFile, Optional.ofNullable(newKey), preData, preDist);
+        }
     }
 
-    void loopObject(JSONObject file, String key, String annotationName, DataClass address, Optional<String> subCat) throws IOException {
-        Object[] fileKeys = file.keySet().toArray();
-        Iterator<?> keysInRamlFile = Arrays.stream(fileKeys).iterator();
+    void addFieldsContainingName(JSONObject file, String key, String annotationName, DataClass address, Optional<String> subCat) throws IOException {
+        if (annotationName == null) return;
 
-        while (keysInRamlFile.hasNext()) {
-            Object keyInRaml = keysInRamlFile.next();
-            if ((annotationName != null) && ((keyInRaml.toString()).contains(annotationName))) {
-
-                String value = file.get(keyInRaml.toString()).toString();
+        for(String keyInRaml : file.keySet()){
+            if(keyInRaml.contains(annotationName)){
+                String value = file.get(keyInRaml).toString();
                 addValues(address, value, key, subCat);
             }
         }
@@ -254,7 +277,7 @@ public class Converter {
                 if (((keyInRaml.toString()).contains(annotationName)) && !((keyInRaml.toString()).equals("temporalResolution"))) {
                     if (((JSONObject) orgConvert.get(key)).keySet().size() > 1) {
                         exists = true;
-                        loopData(file, key, keyInRaml.toString(), key, preData, preDist);
+                        convertNestedObject(file, key, keyInRaml.toString(), key, preData, preDist);
                     }
                 }
             }
@@ -262,6 +285,32 @@ public class Converter {
 
         if (!exists && isMandatory) {
             errors.add("Errormessage: " + annotationName + " is Mandatory");
+        }
+    }
+
+    protected boolean isKeyMandatory(Object key, Optional<String> subCat) {
+        String mandatoryKey;
+        if (subCat.isPresent()) {
+            mandatoryKey = subCat.get() + "-" + key;
+        } else {
+            mandatoryKey = key.toString();
+        }
+        return jsonObjectMandatoryDcat.has(mandatoryKey);
+    }
+
+    protected void addMandatoryError(String annotationName, Optional<String> subCat) {
+        if (subCat.isPresent()) {
+            errors.add("Errormessage: " + annotationName + " in " + subCat.get() + " is Mandatory");
+        } else {
+            errors.add("Errormessage: " + annotationName + " is Mandatory");
+        }
+    }
+
+    protected void handleAddress(JSONObject file, String key, String annotationName, Organization organizationLocal, Optional<String> subCat) throws Exception {
+        if (file.has(annotationName)) {
+            addValues(organizationLocal, String.valueOf(file.get(annotationName)), key, subCat);
+        } else {
+            addFieldsContainingName(file, key, annotationName, organizationLocal, subCat);
         }
     }
 }

--- a/src/main/java/se/ams/dcatprocessor/converter/ConverterCatalog.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/ConverterCatalog.java
@@ -50,47 +50,37 @@ public class ConverterCatalog extends Converter {
     @Override
     void processToDcat(JSONObject subConvert, JSONObject file, Optional<String> subCat, Optional<DataClass> preData, Optional<DataClass> preDist) throws Exception {
         DataClass dataClassLocal = new DataClass();
-        Object[] dcatKeys = subConvert.keySet().toArray();
-        Iterator<?> keysInFile = Arrays.stream(dcatKeys).iterator();
+        
+        for (String key : subConvert.keySet()) {
 
-        while (keysInFile.hasNext()) {
-            Object key = keysInFile.next();
-            if (key.equals(ConverterHelpClass.toDcatString) && (subCat.isPresent())) {
-                if (!keysInFile.hasNext()) {
-                    break;
-                }
-                key = keysInFile.next();
+            if (key.equals(ConverterHelpClass.toDcatString) && subCat.isPresent()) {
+                continue;
             }
 
             // Get tag-name for api-spec
-            String annotationName = subConvert.getJSONObject(key.toString()).getString(ConverterHelpClass.toDcatString);
+            String annotationName = subConvert.getJSONObject(key).getString(ConverterHelpClass.toDcatString);
 
             // Check if tag is Mandatory
-            boolean isMandatory;
-            String mandatoryKey = key.toString();
-            if (subCat.isPresent()) {
-                mandatoryKey = subCat + "-" + key;
-            }
-            isMandatory = jsonObjectMandatoryDcat.has(mandatoryKey);
+            boolean isMandatory = isKeyMandatory(key, subCat);
 
             // Do if key is CATALOG
-            if (key.toString().contains(DCAT.CATALOG.getLocalName())) {
-                createSubset(file, key.toString(), annotationName, Optional.empty(), Optional.empty(), isMandatory);
+            if (key.contains(DCAT.CATALOG.getLocalName())) {
+                createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
             }
             // Do if key is LICENSE_DOCUMENT
-            else if (key.toString().equals(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
+            else if (key.equals(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
                 if (subCat.isPresent()) {
                     if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                        createSubset(file, key.toString(), annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
+                        createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
                     }
                 }
             }
             // Do if key is A Nested Object
-            else if (ConverterHelpClass.isNestedObjects(key.toString())) {
+            else if (ConverterHelpClass.isNestedObjects(key)) {
                 if (subCat.isPresent() && subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                    createSubset(file, key.toString(), annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
                 } else {
-                    createSubset(file, key.toString(), annotationName, Optional.empty(), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
                 }
             }
             /*
@@ -99,12 +89,12 @@ public class ConverterCatalog extends Converter {
                 boolean hasLanguages;
                 if (subCat.isPresent()) {
                     if (ConverterHelpClass.isNestedLanguageObjects(subCat.get())) {
-                        hasLanguages = loopLanguage(file, annotationName, subCat, Optional.of(dataClassLocal), key.toString());
+                        hasLanguages = addLanguageValues(file, annotationName, subCat, Optional.of(dataClassLocal), key);
                     } else {
-                        hasLanguages = loopLanguage(file, annotationName, subCat, Optional.ofNullable(catalog), key.toString());
+                        hasLanguages = addLanguageValues(file, annotationName, subCat, Optional.ofNullable(catalog), key);
                     }
                 } else {
-                    hasLanguages = loopLanguage(file, annotationName, Optional.empty(), Optional.ofNullable(catalog), key.toString());
+                    hasLanguages = addLanguageValues(file, annotationName, Optional.empty(), Optional.ofNullable(catalog), key);
                 }
 
                 if (!hasLanguages) {
@@ -112,35 +102,38 @@ public class ConverterCatalog extends Converter {
                         String value = String.valueOf(file.get(annotationName));
                         if (subCat.isPresent()) {
                             if (ConverterHelpClass.isNestedObjects(subCat.get())) {
-                                addValues(dataClassLocal, value, key.toString(), subCat);
+                                addValues(dataClassLocal, value, key, subCat);
                             } else {
-                                addValues(catalog, value, key.toString(), subCat);
+                                addValues(catalog, value, key, subCat);
                             }
                         }
                     } else if (isMandatory) {
-                        if (subCat.isPresent()) {
-                            errors.add("Errormessage: " + annotationName + " in " + subCat.get() + " is Mandatory");
-                        } else {
-                            errors.add("Errormessage: " + annotationName + " is Mandatory");
-                        }
+                        addMandatoryError(annotationName, subCat);
                     }
                 }
             }
         }
         if (subCat.isPresent()) {
-            if (subCat.get().contains(DCTERMS.PUBLISHER.getLocalName())) {
-                if (preData.isPresent()) {
-                    (preData.get()).agents.add(dataClassLocal);
-                } else {
-                    catalog.publisher = dataClassLocal;
-                }
-            } else if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                catalog.rights = dataClassLocal;
-            } else if (subCat.get().equals(DCTERMS.SPATIAL.getLocalName())) {
-                catalog.spatial.add(dataClassLocal);
-            } else if (subCat.get().contains(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
-                preData.ifPresent(dataClass -> dataClass.licenseDocuments.add(dataClassLocal));
+            attachDataToParent(subCat, preData, dataClassLocal);
+        }
+    }
+
+    // Attaches the locally built dataClassLocal to the correct field on the parent (either preData or catalog)
+    private void attachDataToParent(Optional<String> subCat, Optional<DataClass> preData, DataClass dataClassLocal) {
+        String subCatValue = subCat.get();
+
+        if (subCatValue.contains(DCTERMS.PUBLISHER.getLocalName())) {
+            if (preData.isPresent()) {
+                preData.get().agents.add(dataClassLocal);
+            } else {
+                catalog.publisher = dataClassLocal;
             }
+        } else if (subCatValue.equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
+            catalog.rights = dataClassLocal;
+        } else if (subCatValue.equals(DCTERMS.SPATIAL.getLocalName())) {
+            catalog.spatial.add(dataClassLocal);
+        } else if (subCatValue.contains(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
+            preData.ifPresent(dataClass -> dataClass.licenseDocuments.add(dataClassLocal));
         }
     }
 
@@ -186,16 +179,6 @@ public class ConverterCatalog extends Converter {
             addAbout(dataObj, value);
         } else {
             addValue(dataObj.dcData, value, key, subCat);
-        }
-    }
-
-    @Override
-    void loopData(JSONObject file, String key, String AnnotationName, String newKey, Optional<DataClass> preData, Optional<DataClass> preDist) throws Exception {
-        JSONObject subToConvert = ((JSONObject) orgConvert.get(key));
-        subToConvert.remove(ConverterHelpClass.toDcatMandatoryString);
-        if (subToConvert.keySet().size() > 0) {
-            JSONObject subJsonFile = ((JSONObject) file.get(AnnotationName));
-            processToDcat(subToConvert, subJsonFile, Optional.ofNullable(newKey), preData, preDist);
         }
     }
 }

--- a/src/main/java/se/ams/dcatprocessor/converter/ConverterDataService.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/ConverterDataService.java
@@ -27,8 +27,6 @@ import se.ams.dcatprocessor.models.DataClass;
 import se.ams.dcatprocessor.models.DataService;
 import se.ams.dcatprocessor.models.Organization;
 
-import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Optional;
 
 
@@ -42,125 +40,105 @@ public class ConverterDataService extends Converter {
         Organization organizationLocal = new Organization();
         DataClass dataClassLocal = new DataClass();
 
-        Object[] dcatKeys = subConvert.keySet().toArray();
-        Iterator<?> keysInFile = Arrays.stream(dcatKeys).iterator();
+        for (String key : subConvert.keySet()) {
 
-        while (keysInFile.hasNext()) {
-            Object key = keysInFile.next();
-            if (key.equals(ConverterHelpClass.toDcatString) && (subCat.isPresent())) {
-                if (!keysInFile.hasNext()) {
-                    break;
-                }
-                key = keysInFile.next();
+            if (key.equals(ConverterHelpClass.toDcatString) && subCat.isPresent()) {
+                continue;
             }
 
             // Get tag-name for api-spec
-            String annotationName = subConvert.getJSONObject(key.toString()).getString(ConverterHelpClass.toDcatString);
+            String annotationName = subConvert.getJSONObject(key).getString(ConverterHelpClass.toDcatString);
 
             // Check if tag is Mandatory
-            boolean isMandatory;
-            String mandatoryKey = key.toString();
-            if (subCat.isPresent()) {
-                mandatoryKey = subCat + "-" + key;
-            }
-            isMandatory = jsonObjectMandatoryDcat.has(mandatoryKey);
+            boolean isMandatory = isKeyMandatory(key, subCat);
 
             // Do if key is LICENSE_DOCUMENT
-            if (key.toString().equals(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
+            if (key.equals(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
                 if (subCat.isPresent()) {
                     if (subCat.get().equals(DCAT.DATA_SERVICE.getLocalName())) {
-                        createSubset(file, key.toString(), annotationName, Optional.of(dataService), Optional.empty(), isMandatory);
+                        createSubset(file, key, annotationName, Optional.of(dataService), Optional.empty(), isMandatory);
                     } else if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                        createSubset(file, key.toString(), annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
+                        createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
                     }
                 }
             }
             // Do if key is A Nested Object
-            else if (ConverterHelpClass.isNestedObjects(key.toString())) {
+            else if (ConverterHelpClass.isNestedObjects(key)) {
                 if (subCat.isEmpty()) {
-                    createSubset(file, key.toString(), annotationName, Optional.empty(), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
                 } else if (subCat.get().equals(DCAT.DATA_SERVICE.getLocalName())) {
-                    createSubset(file, key.toString(), annotationName, Optional.of(dataService), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.of(dataService), Optional.empty(), isMandatory);
                 } else if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                    createSubset(file, key.toString(), annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
                 } else {
-                    createSubset(file, key.toString(), annotationName, Optional.empty(), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
                 }
             }
-            /*
-             * Checks for language strings to add them correctly */
+            // Checks for language strings to add them correctly
             else {
                 boolean hasLanguages = false;
                 if (subCat.isPresent()) {
                     if (subCat.get().equals(DCAT.DATA_SERVICE.getLocalName())) {
-                        hasLanguages = loopLanguage(file, annotationName, subCat, Optional.of(dataService), key.toString());
+                        hasLanguages = addLanguageValues(file, annotationName, subCat, Optional.of(dataService), key);
                     } else if (ConverterHelpClass.isNestedLanguageObjects(subCat.get())) {
-                        hasLanguages = loopLanguage(file, annotationName, subCat, Optional.of(dataClassLocal), key.toString());
+                        hasLanguages = addLanguageValues(file, annotationName, subCat, Optional.of(dataClassLocal), key);
                     }
                 }
 
                 if (!hasLanguages) {
                     if (key.equals(VCARD4.ADDRESS.getLocalName())) {
-                        if (file.has(annotationName)) {
-                            String value = String.valueOf(file.get(annotationName));
-                            addValues(organizationLocal, value, key.toString(), subCat);
-                        } else {
-                            loopObject(file, key.toString(), annotationName, organizationLocal, subCat);
-                        }
+                        handleAddress(file, key, annotationName, organizationLocal, subCat);
                     } else if (file.has(annotationName)) {
                         String value = String.valueOf(file.get(annotationName));
                         if (subCat.isPresent()) {
                             if (subCat.get().contains(DCAT.DATA_SERVICE.getLocalName())) {
-                                addValues(dataService, value, key.toString(), subCat);
+                                addValues(dataService, value, key, subCat);
                             } else if (subCat.get().contains(DCAT.CONTACT_POINT.getLocalName())) {
-                                addValues(organizationLocal, value, key.toString(), subCat);
+                                addValues(organizationLocal, value, key, subCat);
                             } else if (ConverterHelpClass.isNestedObjects(subCat.get())) {
-                                addValues(dataClassLocal, value, key.toString(), subCat);
+                                addValues(dataClassLocal, value, key, subCat);
                             }
                         }
                     } else if (isMandatory) {
-                        if (subCat.isPresent()) {
-                            errors.add("Errormessage: " + annotationName + " in " + subCat.get() + " is Mandatory");
-                        } else {
-                            errors.add("Errormessage: " + annotationName + " is Mandatory");
-                        }
+                        addMandatoryError(annotationName, subCat);
                     }
                 }
             }
         }
         if (subCat.isPresent()) {
-            if (subCat.get().contains(DCAT.DATA_SERVICE.getLocalName())) {
-                fileHandler.dataService.add(dataService);
-            } else if (subCat.get().contains(DCTERMS.PUBLISHER.getLocalName())) {
-                if (preData.isPresent()) {
-                    if (preData.get().getClass().equals(DataService.class)) {
-                        ((DataService) preData.get()).agents.add(dataClassLocal);
-                    } else {
-                        preData.get().agent = dataClassLocal;
-                    }
-                }
-            } else if (subCat.get().equals(DCTERMS.STANDARD.getLocalName())) {
-                if (preData.isPresent()) {
-                    preData.get().dcData.put("dcterms:conformsTo",dataClassLocal.about );
-//                preData.ifPresent(dataClass -> ((DataService) dataClass).conformsTo.add(dataClassLocal));
-                }
-            } else if (subCat.get().contains(DCAT.CONTACT_POINT.getLocalName())) {
-                preData.ifPresent(dataClass -> ((DataService) dataClass).organizations.add(organizationLocal));
-            } else if (subCat.get().contains(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
-                preData.ifPresent(dataClass -> dataClass.licenseDocuments.add(dataClassLocal));
-            } else if (subCat.get().contains(FOAF.DOCUMENT.getLocalName())) {
-                preData.ifPresent(dataClass -> dataClass.documents.add(dataClassLocal));
-            }
+            attachDataToParent(subCat, preData, dataService, organizationLocal, dataClassLocal);
         }
     }
 
-    @Override
-    void loopData(JSONObject file, String key, String AnnotationName, String newKey, Optional<DataClass> preData, Optional<DataClass> preDist) throws Exception {
-        JSONObject subToConvert = ((JSONObject) orgConvert.get(key));
-        subToConvert.remove(ConverterHelpClass.toDcatMandatoryString);
-        if (subToConvert.keySet().size() > 0) {
-            JSONObject subJsonFile = ((JSONObject) file.get(AnnotationName));
-            processToDcat(subToConvert, subJsonFile, Optional.ofNullable(newKey), preData, preDist);
+
+    // Attaches the locally built objects (dataService, dataClassLocal, organizationLocal) 
+    // to the correct field on the parent (preData or fileHandler)
+    private void attachDataToParent(Optional<String> subCat, Optional<DataClass> preData, DataService dataService, Organization organizationLocal, DataClass dataClassLocal) {
+        String subCatValue = subCat.get();
+
+        if (subCatValue.contains(DCAT.DATA_SERVICE.getLocalName())) {
+            fileHandler.dataService.add(dataService);
+            return;
+        }
+
+        if (preData.isEmpty()) return;
+        DataClass parent = preData.get();
+        
+        if (subCatValue.contains(DCTERMS.PUBLISHER.getLocalName())) {     
+            if (parent.getClass().equals(DataService.class)) {
+                ((DataService) parent).agents.add(dataClassLocal);
+            } else {
+                parent.agent = dataClassLocal;
+            }
+            
+        } else if (subCatValue.equals(DCTERMS.STANDARD.getLocalName())) {       
+            parent.dcData.put("dcterms:conformsTo", dataClassLocal.about );       
+        } else if (subCatValue.contains(DCAT.CONTACT_POINT.getLocalName())) {
+            ((DataService) parent).organizations.add(organizationLocal);
+        } else if (subCatValue.contains(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
+            parent.licenseDocuments.add(dataClassLocal);
+        } else if (subCatValue.contains(FOAF.DOCUMENT.getLocalName())) {
+            parent.documents.add(dataClassLocal);
         }
     }
 }

--- a/src/main/java/se/ams/dcatprocessor/converter/ConverterDataSet.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/ConverterDataSet.java
@@ -22,12 +22,9 @@ import org.json.JSONObject;
 import se.ams.dcatprocessor.models.*;
 import se.ams.dcatprocessor.rdf.namespace.SCHEMA;
 
-import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Optional;
 
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class ConverterDataSet extends Converter {
 
     /* Process the spec to find elements for dcat-ap-se and add them to an Object to return */
@@ -39,140 +36,121 @@ public class ConverterDataSet extends Converter {
         DataClass dataClassLocal = new DataClass();
         DataClass otherAgent = new DataClass();
 
-        Object[] dcatKeys = subConvert.keySet().toArray();
-        Iterator<?> keysInFile = Arrays.stream(dcatKeys).iterator();
+        for (String key : subConvert.keySet()) {
 
-        while (keysInFile.hasNext()) {
-            Object key = keysInFile.next();
-            if (key.equals(ConverterHelpClass.toDcatString) && (subCat.isPresent())) {
-                if (!keysInFile.hasNext()) {
-                    break;
-                }
-                key = keysInFile.next();
+            if (key.equals(ConverterHelpClass.toDcatString) && subCat.isPresent()) {
+                continue;
             }
 
             // Get tag-name for api-spec
-            String annotationName = subConvert.getJSONObject(key.toString()).getString(ConverterHelpClass.toDcatString);
+            String annotationName = subConvert.getJSONObject(key).getString(ConverterHelpClass.toDcatString);
 
             // Check if tag is Mandatory
-            boolean isMandatory;
-            String mandatoryKey = key.toString();
-            if (subCat.isPresent()) {
-                mandatoryKey = subCat.get() + "-" + key;
-            }
-            isMandatory = jsonObjectMandatoryDcat.has(mandatoryKey);
+            boolean isMandatory = isKeyMandatory(key, subCat);
 
             // Do if key is DISTRIBUTION
-            if (key.toString().equals(DCAT.DISTRIBUTION.getLocalName())) {
+            if (key.equals(DCAT.DISTRIBUTION.getLocalName())) {
                 ConverterDistribution convertDistribution = new ConverterDistribution();
                 convertDistribution.orgConvert = orgConvert;
                 convertDistribution.jsonObjectMandatoryDcat = jsonObjectMandatoryDcat;
                 convertDistribution.fileHandler = fileHandler;
-                convertDistribution.createSubset(file, key.toString(), annotationName, Optional.of(dataSet), Optional.of(distribution), isMandatory);
+                convertDistribution.createSubset(file, key, annotationName, Optional.of(dataSet), Optional.of(distribution), isMandatory);
             }
             // Do if key is LICENSE_DOCUMENT
-            else if (key.toString().equals(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
+            else if (key.equals(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
                 if (subCat.isPresent()) {
                     if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                        createSubset(file, key.toString(), annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
+                        createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
                     }
                 }
             }
             // Do if key is A Nested Object
-            else if (ConverterHelpClass.isNestedObjects(key.toString())) {
+            else if (ConverterHelpClass.isNestedObjects(key)) {
                 if (subCat.get().equals(DCAT.DATASET.getLocalName())) {
-                    createSubset(file, key.toString(), annotationName, Optional.of(dataSet), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.of(dataSet), Optional.empty(), isMandatory);
                 } else {
-                    createSubset(file, key.toString(), annotationName, Optional.empty(), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
                 }
             }
-            /* Checks for language strings to add them correctly */
+            // Checks for language strings to add them correctly
             else {
                 boolean hasLanguages = false;
                 if (subCat.isPresent()) {
                     if (subCat.get().equals(DCAT.DATASET.getLocalName())) {
-                        hasLanguages = loopLanguage(file, annotationName, subCat, Optional.of(dataSet), key.toString());
+                        hasLanguages = addLanguageValues(file, annotationName, subCat, Optional.of(dataSet), key);
                     } else if (ConverterHelpClass.isNestedLanguageObjects(subCat.get())) {
-                        hasLanguages = loopLanguage(file, annotationName, subCat, Optional.of(dataClassLocal), key.toString());
+                        hasLanguages = addLanguageValues(file, annotationName, subCat, Optional.of(dataClassLocal), key);
                     }
                 }
                 if (!hasLanguages) {
                     if (key.equals(VCARD4.ADDRESS.getLocalName())) {
-                        if (file.has(annotationName)) {
-                            String value = String.valueOf(file.get(annotationName));
-                            addValues(organizationLocal, value, key.toString(), subCat);
-                        } else {
-                            loopObject(file, key.toString(), annotationName, organizationLocal, subCat);
-                        }
+                        handleAddress(file, key, annotationName, organizationLocal, subCat);
                     } else if (file.has(annotationName)) {
                         String value = String.valueOf(file.get(annotationName));
                         if (subCat.isPresent()) {
                             if (subCat.get().contains(DCAT.DATASET.getLocalName())) {
-                                addValues(dataSet, value, key.toString(), subCat);
+                                addValues(dataSet, value, key, subCat);
                             } else if (subCat.get().contains(DCAT.CONTACT_POINT.getLocalName())) {
-                                addValues(organizationLocal, value, key.toString(), subCat);
+                                addValues(organizationLocal, value, key, subCat);
                             } else if (subCat.get().contains(PROV.ATTRIBUTION.getLocalName())) {
-                                if (key.toString().equals("dcat:hadRole")) {
-                                    addValues(dataClassLocal, value, key.toString(), subCat);
+                                if (key.equals("dcat:hadRole")) {
+                                    addValues(dataClassLocal, value, key, subCat);
                                 }
                                 else {
-                                    addValues(otherAgent, value, key.toString(), subCat);
+                                    addValues(otherAgent, value, key, subCat);
                                 }
                             } else if (ConverterHelpClass.isNestedObjects(subCat.get())) {
-                                addValues(dataClassLocal, value, key.toString(), subCat);
+                                addValues(dataClassLocal, value, key, subCat);
                             }
                         }
                     } else if (isMandatory) {
-                        if (subCat.isPresent()) {
-                            errors.add("Errormessage: " + annotationName + " in " + subCat.get() + " is Mandatory");
-                        } else {
-                            errors.add("Errormessage: " + annotationName + " is Mandatory");
-                        }
+                        addMandatoryError(annotationName, subCat);
                     }
                 }
             }
         }
         if (subCat.isPresent()) {
-            if (subCat.get().contains(DCAT.DATASET.getLocalName())) {
-                fileHandler.dcat_dataset.add(dataSet);
-            } else if (subCat.get().contains(DCTERMS.PUBLISHER.getLocalName())) {
-                if (preData.isPresent()) {
-                    preData.get().agent = dataClassLocal;
-                }
-            } else if (subCat.get().contains(DCTERMS.CREATOR.getLocalName())) {
-                preData.ifPresent(dataClass -> ((DataSet) dataClass).creator = dataClassLocal);
-            } else if (subCat.get().contains(PROV.ATTRIBUTION.getLocalName())) {
-                dataClassLocal.agent = otherAgent;
-                preData.ifPresent(dataClass -> ((DataSet) dataClass).otherAgents.add(dataClassLocal));
-            } else if (subCat.get().equals(DCTERMS.TEMPORAL.getLocalName())) {
-                preData.ifPresent(dataClass -> ((DataSet) dataClass).temporals.add(dataClassLocal));
-            } else if (subCat.get().equals(SCHEMA.OFFERS.getLocalName())) {
-                preData.ifPresent(dataClass -> ((DataSet) dataClass).offers.add(dataClassLocal));
-            } else if (subCat.get().equals(DCTERMS.STANDARD.getLocalName())) {
-                preData.ifPresent(dataClass -> ((DataSet) dataClass).conformsTo.add(dataClassLocal));
-            } else if (subCat.get().equals(DCTERMS.SPATIAL.getLocalName())) {
-                if (preData.isPresent()) {
-                    ((DataSet) preData.get()).spatial.add(dataClassLocal);
-                }
-            } else if (subCat.get().contains(DCAT.QUALIFIED_RELATION.getLocalName())) {
-                if (preData.isPresent()) {
-                    ((DataSet) preData.get()).qualifiedRelations.add(dataClassLocal);
-                }
-            } else if (subCat.get().contains(DCAT.CONTACT_POINT.getLocalName())) {
-                preData.ifPresent(dataClass -> ((DataSet) dataClass).organizations.add(organizationLocal));
-            } else if (subCat.get().contains(FOAF.DOCUMENT.getLocalName())) {
-                preData.ifPresent(dataClass -> dataClass.documents.add(dataClassLocal));
-            }
+            attachDataToParent(subCat, preData, dataSet, organizationLocal, dataClassLocal, otherAgent);
         }
     }
 
-    @Override
-    void loopData(JSONObject file, String key, String AnnotationName, String newKey, Optional<DataClass> preData, Optional<DataClass> preDist) throws Exception {
-        JSONObject subToConvert = ((JSONObject) orgConvert.get(key));
-        subToConvert.remove(ConverterHelpClass.toDcatMandatoryString);
-        if (subToConvert.keySet().size() > 0) {
-            JSONObject subJsonFile = ((JSONObject) file.get(AnnotationName));
-            processToDcat(subToConvert, subJsonFile, Optional.ofNullable(newKey), preData, preDist);
+    
+    // Attaches the locally built objects (dataClassLocal, dataSet, organizationLocal, otherAgent)
+    // to the correct field on the parent (preData or fileHandler)
+    private void attachDataToParent(Optional<String> subCat, Optional<DataClass> preData, DataSet dataSet,
+            Organization organizationLocal, DataClass dataClassLocal, DataClass otherAgent) {
+
+        String subCatValue = subCat.get();
+
+        if (subCatValue.contains(DCAT.DATASET.getLocalName())) {
+            fileHandler.dcat_dataset.add(dataSet);
+            return;
+        }
+
+        if (preData.isEmpty()) return;
+        DataClass parentData = preData.get();
+
+        if (subCatValue.contains(DCTERMS.PUBLISHER.getLocalName())) {
+            parentData.agent = dataClassLocal;
+        } else if (subCatValue.contains(DCTERMS.CREATOR.getLocalName())) {
+            ((DataSet) parentData).creator = dataClassLocal;
+        } else if (subCatValue.contains(PROV.ATTRIBUTION.getLocalName())) {
+            dataClassLocal.agent = otherAgent;
+            ((DataSet) parentData).otherAgents.add(dataClassLocal);
+        } else if (subCatValue.equals(DCTERMS.TEMPORAL.getLocalName())) {
+            ((DataSet) parentData).temporals.add(dataClassLocal);
+        } else if (subCatValue.equals(SCHEMA.OFFERS.getLocalName())) {
+            ((DataSet) parentData).offers.add(dataClassLocal);
+        } else if (subCatValue.equals(DCTERMS.STANDARD.getLocalName())) {
+            ((DataSet) parentData).conformsTo.add(dataClassLocal);
+        } else if (subCatValue.equals(DCTERMS.SPATIAL.getLocalName())) {
+            ((DataSet) parentData).spatial.add(dataClassLocal);
+        } else if (subCatValue.contains(DCAT.QUALIFIED_RELATION.getLocalName())) {
+            ((DataSet) parentData).qualifiedRelations.add(dataClassLocal);
+        } else if (subCatValue.contains(DCAT.CONTACT_POINT.getLocalName())) {
+            ((DataSet) parentData).organizations.add(organizationLocal);
+        } else if (subCatValue.contains(FOAF.DOCUMENT.getLocalName())) {
+            parentData.documents.add(dataClassLocal);
         }
     }
 }

--- a/src/main/java/se/ams/dcatprocessor/converter/ConverterDistribution.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/ConverterDistribution.java
@@ -25,8 +25,6 @@ import org.json.JSONObject;
 import se.ams.dcatprocessor.models.*;
 import se.ams.dcatprocessor.rdf.namespace.SPDX;
 
-import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Optional;
 
 
@@ -39,143 +37,126 @@ public class ConverterDistribution extends Converter {
         Distribution distribution = new Distribution();
         Organization organizationLocal = new Organization();
         DataClass dataClassLocal = new DataClass();
-        Object[] dcatKeys = subConvert.keySet().toArray();
-        Iterator<?> keysInFile = Arrays.stream(dcatKeys).iterator();
 
-        while (keysInFile.hasNext()) {
-            Object key = keysInFile.next();
-            if (key.equals(ConverterHelpClass.toDcatString) && (subCat.isPresent())) {
-                if (!keysInFile.hasNext()) {
-                    break;
-                }
-                key = keysInFile.next();
+        for (String key : subConvert.keySet()) {
+
+            if (key.equals(ConverterHelpClass.toDcatString) && subCat.isPresent()) {
+                continue;
             }
 
             // Get tag-name for api-spec
-            String annotationName = subConvert.getJSONObject(key.toString()).getString(ConverterHelpClass.toDcatString);
+            String annotationName = subConvert.getJSONObject(key).getString(ConverterHelpClass.toDcatString);
 
             // Check if tag is Mandatory
-            boolean isMandatory;
-            String mandatoryKey = key.toString();
-            if (subCat.isPresent()) {
-                mandatoryKey = subCat + "-" + key;
-            }
-            isMandatory = jsonObjectMandatoryDcat.has(mandatoryKey);
+            boolean isMandatory = isKeyMandatory(key, subCat);
 
             // Do if key is DISTRIBUTION
-            if (key.toString().equals(DCAT.DISTRIBUTION.getLocalName())) {
-                createSubset(file, key.toString(), annotationName, Optional.of(dataSet), Optional.of(distribution), isMandatory);
+            if (key.equals(DCAT.DISTRIBUTION.getLocalName())) {
+                createSubset(file, key, annotationName, Optional.of(dataSet), Optional.of(distribution), isMandatory);
             }
             // Do if key is LICENSE_DOCUMENT
-            else if (key.toString().equals(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
+            else if (key.equals(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
                 if (subCat.isPresent()) {
                     if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                        createSubset(file, key.toString(), annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
+                        createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
                     } else {
-                        createSubset(file, key.toString(), annotationName, Optional.of(dataClassLocal), Optional.of(distribution), isMandatory);
+                        createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.of(distribution), isMandatory);
                     }
                 } else {
-                    createSubset(file, key.toString(), annotationName, preData, Optional.of(distribution), isMandatory);
+                    createSubset(file, key, annotationName, preData, Optional.of(distribution), isMandatory);
                 }
             }
             // Do if key is A Nested Object
-            else if (ConverterHelpClass.isNestedObjects(key.toString())) {
+            else if (ConverterHelpClass.isNestedObjects(key)) {
                 if (subCat.isEmpty()) {
-                    createSubset(file, key.toString(), annotationName, Optional.empty(), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
                 } else if (subCat.get().equals(DCAT.DISTRIBUTION.getLocalName())) {
-                    createSubset(file, key.toString(), annotationName, Optional.empty(), Optional.of(distribution), isMandatory);
+                    createSubset(file, key, annotationName, Optional.empty(), Optional.of(distribution), isMandatory);
                 } else if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                    createSubset(file, key.toString(), annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
                 } else {
-                    createSubset(file, key.toString(), annotationName, Optional.empty(), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
                 }
             }
-            /*
-             * Checks for language strings to add them correctly */
+            
+            // Checks for language strings to add them correctly
             else {
                 boolean hasLanguages;
                 if (subCat.isPresent()) {
                     if (subCat.get().equals(DCAT.DISTRIBUTION.getLocalName())) {
-                        hasLanguages = loopLanguage(file, annotationName, subCat, Optional.of(distribution), key.toString());
+                        hasLanguages = addLanguageValues(file, annotationName, subCat, Optional.of(distribution), key);
                     } else if (ConverterHelpClass.isNestedLanguageObjects(subCat.get())) {
-                        hasLanguages = loopLanguage(file, annotationName, subCat, Optional.of(dataClassLocal), key.toString());
+                        hasLanguages = addLanguageValues(file, annotationName, subCat, Optional.of(dataClassLocal), key);
                     } else {
-                        hasLanguages = loopLanguage(file, annotationName, subCat, Optional.ofNullable(catalog), key.toString());
+                        hasLanguages = addLanguageValues(file, annotationName, subCat, Optional.ofNullable(catalog), key);
                     }
                 } else {
-                    hasLanguages = loopLanguage(file, annotationName, Optional.empty(), Optional.ofNullable(catalog), key.toString());
+                    hasLanguages = addLanguageValues(file, annotationName, Optional.empty(), Optional.ofNullable(catalog), key);
                 }
                 if (!hasLanguages) {
                     if (key.equals(VCARD4.ADDRESS.getLocalName())) {
-                        if (file.has(annotationName)) {
-                            String value = String.valueOf(file.get(annotationName));
-                            addValues(organizationLocal, value, key.toString(), subCat);
-                        } else {
-                            loopObject(file, key.toString(), annotationName, organizationLocal, subCat);
-                        }
+                        handleAddress(file, key, annotationName, organizationLocal, subCat);
                     } else if (file.has(annotationName)) {
                         String value = String.valueOf(file.get(annotationName));
                         if (subCat.isPresent()) {
                             if (subCat.get().contains(DCAT.DATASET.getLocalName())) {
-                                addValues(dataSet, value, key.toString(), subCat);
+                                addValues(dataSet, value, key, subCat);
                             } else if (subCat.get().contains(DCAT.DISTRIBUTION.getLocalName())) {
-                                addValues(distribution, value, key.toString(), subCat);
+                                addValues(distribution, value, key, subCat);
                             } else if (subCat.get().contains(DCAT.CONTACT_POINT.getLocalName())) {
-                                addValues(organizationLocal, value, key.toString(), subCat);
+                                addValues(organizationLocal, value, key, subCat);
                             } else if (ConverterHelpClass.isNestedObjects(subCat.get())) {
-                                addValues(dataClassLocal, value, key.toString(), subCat);
+                                addValues(dataClassLocal, value, key, subCat);
                             }
                         }
                     } else if (isMandatory) {
-                        if (subCat.isPresent()) {
-                            errors.add("Errormessage: " + annotationName + " in " + subCat.get() + " is Mandatory");
-                        } else {
-                            errors.add("Errormessage: " + annotationName + " is Mandatory");
-                        }
+                        addMandatoryError(annotationName, subCat);
                     }
                 }
             }
         }
         if (subCat.isPresent()) {
-            if (subCat.get().contains(DCTERMS.PUBLISHER.getLocalName())) {
-                if (preData.isPresent()) {
-                    (preData.get()).agents.add(dataClassLocal);
-                }
-            } else if (subCat.get().equals(SPDX.CHECKSUM.getLocalName())) {
-                dataClassLocal.dcData.put("spdx:algorithm", "http://spdx.org/rdf/terms#checksumAlgorithm_sha1");
-                preDist.ifPresent(dataClass -> ((Distribution) dataClass).checksum = dataClassLocal);
-            } else if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                if (preData.isPresent()) {
-                    ((Distribution) preDist.get()).rights = dataClassLocal;
-                }
-            } else if (subCat.get().equals(DCTERMS.STANDARD.getLocalName())) {
-                preDist.get().dcData.put("dcterms:conformsTo",dataClassLocal.about );
-            //    ((Distribution) preDist.get()).conformsTo.add(dataClassLocal);
-            } else if (subCat.get().equals(DCTERMS.SPATIAL.getLocalName())) {
-                ((DataSet) preData.get()).spatial.add(dataClassLocal);
-            } else if (subCat.get().contains(DCAT.DISTRIBUTION.getLocalName())) {
-                preData.ifPresent(dataClass -> ((DataSet) dataClass).dcat_distribution.add(distribution));
-            } else if (subCat.get().contains(DCAT.CONTACT_POINT.getLocalName())) {
-                preData.ifPresent(dataClass -> ((DataService) dataClass).organizations.add(organizationLocal));
-            } else if (subCat.get().contains(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
-                if (preDist.isPresent()) {
-                    preDist.get().licenseDocuments.add(dataClassLocal);
-                } else preData.ifPresent(dataClass -> dataClass.licenseDocuments.add(dataClassLocal));
-            } else if (subCat.get().contains(FOAF.DOCUMENT.getLocalName())) {
-                if (preDist.isPresent()) {
-                    preDist.get().documents.add(dataClassLocal);
-                } else preData.ifPresent(dataClass -> dataClass.documents.add(dataClassLocal));
-            }
+            attachDataToParent(subCat, preData, preDist, distribution, organizationLocal, dataClassLocal);
         }
     }
 
-    @Override
-    void loopData(JSONObject file, String key, String AnnotationName, String newKey, Optional<DataClass> preData, Optional<DataClass> preDist) throws Exception {
-        JSONObject subToConvert = ((JSONObject) orgConvert.get(key));
-        subToConvert.remove(ConverterHelpClass.toDcatMandatoryString);
-        if (subToConvert.keySet().size() > 0) {
-            JSONObject subJsonFile = ((JSONObject) file.get(AnnotationName));
-            processToDcat(subToConvert, subJsonFile, Optional.ofNullable(newKey), preData, preDist);
+    
+    // Attaches the locally built objects (dataClassLocal, distribution, organizationLocal) 
+    // to the correct field on the parent context (preData or preDist)
+    private void attachDataToParent(Optional<String> subCat, Optional<DataClass> preData, Optional<DataClass> preDist, Distribution distribution, 
+        Organization organizationLocal, DataClass dataClassLocal) {
+        
+        String subCatValue = subCat.get();
+        DataClass parentData = preData.orElse(null);
+        DataClass parentDist = preDist.orElse(null);
+
+        if (subCatValue.contains(DCTERMS.PUBLISHER.getLocalName()) && parentData != null) {
+            parentData.agents.add(dataClassLocal);
+        } else if (subCatValue.equals(SPDX.CHECKSUM.getLocalName()) && parentDist != null) {
+            dataClassLocal.dcData.put("spdx:algorithm", "http://spdx.org/rdf/terms#checksumAlgorithm_sha1");
+            ((Distribution) parentDist).checksum = dataClassLocal;
+        } else if (subCatValue.equals(DCTERMS.RIGHTS_STATEMENT.getLocalName()) && parentDist != null) {
+            ((Distribution) parentDist).rights = dataClassLocal;
+        } else if (subCatValue.equals(DCTERMS.STANDARD.getLocalName()) && parentDist != null) {
+            parentDist.dcData.put("dcterms:conformsTo", dataClassLocal.about);
+        } else if (subCatValue.equals(DCTERMS.SPATIAL.getLocalName()) && parentData != null) {
+            ((DataSet) parentData).spatial.add(dataClassLocal);
+        } else if (subCatValue.contains(DCAT.DISTRIBUTION.getLocalName()) && parentData != null) {
+            ((DataSet) parentData).dcat_distribution.add(distribution);
+        } else if (subCatValue.contains(DCAT.CONTACT_POINT.getLocalName()) && parentData != null) {
+            ((DataService) parentData).organizations.add(organizationLocal);
+        } else if (subCatValue.contains(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
+            if (parentDist != null) {
+                parentDist.licenseDocuments.add(dataClassLocal);
+            } else if(parentData != null){
+                parentData.licenseDocuments.add(dataClassLocal);
+            }          
+        } else if (subCatValue.contains(FOAF.DOCUMENT.getLocalName())) {
+            if (parentDist != null) {
+                parentDist.documents.add(dataClassLocal);
+            } else if(parentData != null){
+                parentData.documents.add(dataClassLocal);
+            }
         }
     }
 }

--- a/src/main/java/se/ams/dcatprocessor/converter/ConverterFiles.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/ConverterFiles.java
@@ -52,114 +52,105 @@ public class ConverterFiles extends Converter {
         Distribution distribution = new Distribution();
         Organization organizationLocal = new Organization();
         DataClass dataClassLocal = new DataClass();
-        Object[] dcatKeys = subConvert.keySet().toArray();
-        Iterator<?> keysInFile = Arrays.stream(dcatKeys).iterator();
 
-        while (keysInFile.hasNext()) {
-            Object key = keysInFile.next();
-            if (key.equals(ConverterHelpClass.toDcatString) && (subCat.isPresent())) {
-                if (!keysInFile.hasNext()) {
-                    break;
-                }
-                key = keysInFile.next();
+        for (String key : subConvert.keySet()) {
+
+            if (key.equals(ConverterHelpClass.toDcatString) && subCat.isPresent()) {
+                continue;
             }
 
             // Get tag-name for api-spec
-            String annotationName = subConvert.getJSONObject(key.toString()).getString(ConverterHelpClass.toDcatString);
+            String annotationName = subConvert.getJSONObject(key).getString(ConverterHelpClass.toDcatString);
 
             // Check if tag is Mandatory
-            boolean isMandatory;
-            String mandatoryKey = key.toString();
-            if (subCat.isPresent()) {
-                mandatoryKey = subCat + "-" + key;
-            }
-            isMandatory = jsonObjectMandatoryDcat.has(mandatoryKey);
+            boolean isMandatory = isKeyMandatory(key, subCat);
 
             // Do if key is DATASET
-            if (key.toString().contains(DCAT.DATASET.getLocalName())) {
+            if (key.contains(DCAT.DATASET.getLocalName())) {
                 ConverterDataSet convertDataSet = new ConverterDataSet();
                 convertDataSet.orgConvert = orgConvert;
                 convertDataSet.jsonObjectMandatoryDcat = jsonObjectMandatoryDcat;
                 convertDataSet.fileHandler = fileHandler;
-                convertDataSet.createSubset(file, key.toString(), annotationName, Optional.of(dataSet), Optional.empty(), isMandatory);
+                convertDataSet.createSubset(file, key, annotationName, Optional.of(dataSet), Optional.empty(), isMandatory);
             }
             // Do if key is LICENSE_DOCUMENT
-            else if (key.toString().equals(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
+            else if (key.equals(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
                 if (subCat.isPresent()) {
                     if (subCat.get().equals(DCAT.DATA_SERVICE.getLocalName())) {
-                        createSubset(file, key.toString(), annotationName, Optional.of(dataService), Optional.empty(), isMandatory);
+                        createSubset(file, key, annotationName, Optional.of(dataService), Optional.empty(), isMandatory);
                     } else if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                        createSubset(file, key.toString(), annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
+                        createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
                     } else {
-                        createSubset(file, key.toString(), annotationName, Optional.empty(), Optional.of(distribution), isMandatory);
+                        createSubset(file, key, annotationName, Optional.empty(), Optional.of(distribution), isMandatory);
                     }
                 } else {
-                    createSubset(file, key.toString(), annotationName, preData, Optional.of(distribution), isMandatory);
+                    createSubset(file, key, annotationName, preData, Optional.of(distribution), isMandatory);
                 }
             }
             // Do if key is DATASERVICE
-            else if (key.toString().contains(DCAT.DATA_SERVICE.getLocalName())) {
+            else if (key.contains(DCAT.DATA_SERVICE.getLocalName())) {
                 ConverterDataService convertDataService = new ConverterDataService();
                 convertDataService.orgConvert = orgConvert;
                 convertDataService.jsonObjectMandatoryDcat = jsonObjectMandatoryDcat;
                 convertDataService.fileHandler = fileHandler;
-                convertDataService.createSubset(file, key.toString(), annotationName, Optional.of(dataService), Optional.empty(), isMandatory);
+                convertDataService.createSubset(file, key, annotationName, Optional.of(dataService), Optional.empty(), isMandatory);
             }
             // Do if key is A Nested Object
-            else if (ConverterHelpClass.isNestedObjects(key.toString())) {
+            else if (ConverterHelpClass.isNestedObjects(key)) {
                 if (subCat.isEmpty()) {
-                    createSubset(file, key.toString(), annotationName, Optional.empty(), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
                 } else if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                    createSubset(file, key.toString(), annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
                 } else {
-                    createSubset(file, key.toString(), annotationName, Optional.empty(), Optional.empty(), isMandatory);
+                    createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
                 }
             }
-            /*
-             * Checks for language strings to add them correctly */
+            
+            // Checks for language strings to add them correctly
             else {
                 boolean hasLanguages = false;
                 if (subCat.isPresent()) {
                     if (ConverterHelpClass.isNestedLanguageObjects(subCat.get())) {
-                        hasLanguages = loopLanguage(file, annotationName, subCat, Optional.of(dataClassLocal), key.toString());
+                        hasLanguages = addLanguageValues(file, annotationName, subCat, Optional.of(dataClassLocal), key);
                     }
                 }
                 if (!hasLanguages) {
                     if (key.equals(VCARD4.ADDRESS.getLocalName())) {
-                        if (file.has(annotationName)) {
-                            String value = String.valueOf(file.get(annotationName));
-                            addValues(organizationLocal, value, key.toString(), subCat);
-                        } else {
-                            loopObject(file, key.toString(), annotationName, organizationLocal, subCat);
-                        }
+                        handleAddress(file, key, annotationName, organizationLocal, subCat);
                     } else if (file.has(annotationName)) {
                         String value = String.valueOf(file.get(annotationName));
                         if (subCat.isPresent()) {
                             if (subCat.get().contains(DCAT.CONTACT_POINT.getLocalName())) {
-                                addValues(organizationLocal, value, key.toString(), subCat);
+                                addValues(organizationLocal, value, key, subCat);
                             } else if (ConverterHelpClass.isNestedObjects(subCat.get())) {
-                                addValues(dataClassLocal, value, key.toString(), subCat);
+                                addValues(dataClassLocal, value, key, subCat);
                             }
                         }
                     } else if (isMandatory) {
-                        if (subCat.isPresent()) {
-                            errors.add("Errormessage: " + annotationName + " in " + subCat.get() + " is Mandatory");
-                        } else {
-                            errors.add("Errormessage: " + annotationName + " is Mandatory");
-                        }
+                        addMandatoryError(annotationName, subCat);
                     }
                 }
             }
         }
         if (subCat.isPresent()) {
-            if (subCat.get().contains(DCTERMS.PUBLISHER.getLocalName())) {
-                preData.get().agent = dataClassLocal;
-            } else if (subCat.get().contains(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
-                preData.ifPresent(dataClass -> dataClass.licenseDocuments.add(dataClassLocal));
-            } else if (subCat.get().contains(FOAF.DOCUMENT.getLocalName())) {
-                preData.ifPresent(dataClass -> dataClass.documents.add(dataClassLocal));
-            }
+            attachDataToParent(subCat, preData, dataClassLocal);
         }
     }
 
+    
+    // Attaches the locally built dataClassLocal to the correct field on preData
+    private void attachDataToParent(Optional<String> subCat, Optional<DataClass> preData, DataClass dataClassLocal) {
+        if (preData.isEmpty()) return;
+        
+        String subCatValue = subCat.get();
+        DataClass parent = preData.get();
+        
+        if (subCatValue.contains(DCTERMS.PUBLISHER.getLocalName())) {
+            parent.agent = dataClassLocal;
+        } else if (subCatValue.contains(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
+            parent.licenseDocuments.add(dataClassLocal);
+        } else if (subCatValue.contains(FOAF.DOCUMENT.getLocalName())) {
+            parent.documents.add(dataClassLocal);
+        }
+    }
 }

--- a/src/main/java/se/ams/dcatprocessor/parser/ApiDefinitionParser.java
+++ b/src/main/java/se/ams/dcatprocessor/parser/ApiDefinitionParser.java
@@ -28,25 +28,16 @@ import org.yaml.snakeyaml.nodes.*;
 import se.ams.dcatprocessor.rdf.DcatException;
 
 import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ApiDefinitionParser {
 
     public static JSONObject getApiJsonString(String fileString) throws IOException, JSONException  {
-        Stream<String> lines;
-        String apiJsonString = "";
-        JSONObject jsonObjectFile;
+        String apiJsonString;
+        String apiLine1 = fileString.lines().findFirst().orElse("");
 
-        lines = fileString.lines();
-        String apiLine1 = lines.limit(1).collect(Collectors.joining("\n"));
-
-        if (apiLine1.contains("openapi")) {
-            apiJsonString = getFileApiYamlRaml(fileString);
-        } else if (apiLine1.contains("RAML")) {
+        if (apiLine1.contains("openapi") || apiLine1.contains("RAML")) {
             apiJsonString = getFileApiYamlRaml(fileString);
         } else if (apiLine1.contains("{")){
             apiJsonString = fileString;
@@ -55,6 +46,7 @@ public class ApiDefinitionParser {
             throw new DcatException("not supported api definition");
         }
 
+        JSONObject jsonObjectFile;
         try {
             jsonObjectFile = new JSONObject(apiJsonString);
         } catch (JSONException e) {
@@ -69,27 +61,24 @@ public class ApiDefinitionParser {
     }
 
     private static String getFileApiYamlRaml(String apiSpec) throws IOException {
-        FileOutputStream output = new FileOutputStream("output.json");
         JsonFactory factory = new JsonFactory();
-        JsonGenerator generator = factory.createGenerator(output, JsonEncoding.UTF8);
 
-        try {
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream();
+            JsonGenerator generator = factory.createGenerator(output, JsonEncoding.UTF8)) {
+
             Yaml yamlParser = new Yaml();
             yamlParser.addImplicitResolver(Tag.YAML, Pattern.compile("^(!)$"), "!");
             Node compose = yamlParser.compose(new StringReader(apiSpec));
+            
             build(compose, generator);
-            generator.close();
-            output.close();
-
-            //Read JSON file
-            String jsonString = new String(Files.readAllBytes(Paths.get("output.json")));
-            Object obj = new JSONObject(jsonString);
-            return obj.toString();
-
-        } catch (IOException | JSONException e) {
-            e.printStackTrace();
+            generator.flush();
+            
+            String jsonString = output.toString(StandardCharsets.UTF_8);
+            return new JSONObject(jsonString).toString();
+            
+        } catch (JSONException e) {
+            throw new IOException("Failed to parse YAML/RAML as JSON: " + e.getMessage(), e);
         }
-        return "";
     }
 
     private static void build(Node yaml, JsonGenerator generator) throws IOException {

--- a/src/main/java/se/ams/dcatprocessor/processor/ErrorReporter.java
+++ b/src/main/java/se/ams/dcatprocessor/processor/ErrorReporter.java
@@ -1,0 +1,45 @@
+package se.ams.dcatprocessor.processor;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import se.ams.dcatprocessor.rdf.validate.ValidationError;
+
+@Component
+public class ErrorReporter {
+
+    private static final String DOCS_URL = "https://docs.dataportal.se/dcat/sv/";
+
+    public String buildErrorReport(Map<String, String> exceptions, Map<String, List<ValidationError>> validationErrors) {
+        StringBuilder errors = new StringBuilder();
+        StringBuilder report = new StringBuilder();
+
+        // Errors from ApiDefinitionParser or Converters
+        if (!exceptions.isEmpty()) {
+            errors.append("\n");
+            exceptions.forEach((key, value) -> errors.append(key).append(":\n").append(value).append("\n\n"));
+        }
+
+        // Errors from RDFWorker
+        if (!validationErrors.isEmpty()) {
+            errors.append("\n");
+            validationErrors.forEach((key, value) -> {
+                errors.append(key).append(":\n");
+                for (ValidationError error : value) {
+                    errors.append("Errortype: ").append(error.getErrorType())
+                          .append(" Description: ").append(error.getDescription()).append("\n");
+                }
+                errors.append("\n");
+            });
+        }
+        
+        if(!errors.isEmpty()){
+            report.append("Check DCAT-AP-SE specification for info. " + DOCS_URL + "\n---------------------------------\n");
+            report.append(errors);
+        }
+        
+        return report.toString();
+    }
+}

--- a/src/main/java/se/ams/dcatprocessor/processor/Manager.java
+++ b/src/main/java/se/ams/dcatprocessor/processor/Manager.java
@@ -15,7 +15,7 @@
  * along with dcat-ap-se-processor.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package se.ams.dcatprocessor;
+package se.ams.dcatprocessor.processor;
 
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
@@ -27,6 +27,8 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 import org.springframework.ui.Model;
 import org.springframework.web.multipart.MultipartFile;
+
+import se.ams.dcatprocessor.controller.Result;
 import se.ams.dcatprocessor.converter.Converter;
 import se.ams.dcatprocessor.converter.ConverterCatalog;
 import se.ams.dcatprocessor.converter.ConverterFiles;
@@ -51,14 +53,18 @@ import java.util.*;
 public class Manager {
 
     private final ObjectProvider<RDFWorker> rdfWorkerProvider;
-
-    public Manager(ObjectProvider<RDFWorker> rdfWorkerProvider){
-        this.rdfWorkerProvider = rdfWorkerProvider;
-    }
+    private final ErrorReporter errorReporter; 
 
     private static final Logger logger = LoggerFactory.getLogger(Manager.class);
+    
     Catalog catalog = new Catalog();
     List<FileStorage> fileStorages = new ArrayList<>();
+
+    
+    public Manager(ObjectProvider<RDFWorker> rdfWorkerProvider, ErrorReporter errorReporter){
+        this.rdfWorkerProvider = rdfWorkerProvider;
+        this.errorReporter = errorReporter;
+    }
 
     public String createDcatFromDirectory(String dir) throws Exception {
         // create new file
@@ -122,7 +128,7 @@ public class Manager {
                     apiSpecMap.put(apiFile.getOriginalFilename(), apiSpecificationFromFile);
                 } catch (Exception e) {        //Catch and show processing errors in web-gui
                     result = e.getMessage();
-                    results.add(new Result(null, result));
+                    results.add(new Result(result));
                     e.printStackTrace();
                 }
             }
@@ -131,10 +137,10 @@ public class Manager {
             result = createDcat(apiSpecMap);
         } catch (Exception e) {
             result = e.getMessage();
-            results.add(new Result(null, result));
+            results.add(new Result(result));
             e.printStackTrace();
         }
-        results.add(new Result(null, result));
+        results.add(new Result(result));
 
         model.addAttribute("results", results);
         return results;
@@ -151,7 +157,6 @@ public class Manager {
     }
 
     public String createDcat(MultiValuedMap<String, String> apiSpecMap) throws Exception {
-        ConverterCatalog catalogConverter = new ConverterCatalog();
         RDFWorker rdfWorker = rdfWorkerProvider.getObject();
         resetValidationErrors();
 
@@ -164,41 +169,15 @@ public class Manager {
             for (String apiSpecString : api) {
                 JSONObject jsonObjectFile = ApiDefinitionParser.getApiJsonString(apiSpecString);
 
-                // Creates both Catalog and other spec from the same file
-                if (apiSpecMap.size() == 1) {
-                    try {
-                        catalog = (Catalog) catalogConverter.catalogToDcat(jsonObjectFile);
-                        catalog.fileName = apiFileName;
-                    } catch (Exception e) {
-                        exceptions.put(apiFileName, e.fillInStackTrace().getMessage());
-                    }
-                    try {
-                        ConverterFiles filesConverter = new ConverterFiles();
-                        FileStorage fileStorage = (FileStorage) filesConverter.fileToDcat(jsonObjectFile);
-                        fileStorage.fileName = apiFileName;
-                        fileStorages.add(fileStorage);
-                    } catch (Exception e) {
-                        exceptions.put(apiFileName, e.fillInStackTrace().getMessage());
-                    }
-                    // Creates Catalog from specific file
-                } else if (apiFileName.contains(ConverterHelpClass.catalogFileName)) {
-                    try {
-                        catalog = (Catalog) catalogConverter.catalogToDcat(jsonObjectFile);
-                        catalog.fileName = apiFileName;
-                    } catch (Exception e) {
-                        exceptions.put(apiFileName, e.fillInStackTrace().getMessage());
-                    }
-                    // Creates all other spec besides Catalog from file
-                } else {
-                    try {
-                        ConverterFiles filesConverter = new ConverterFiles();
-                        FileStorage fileStorage;
-                        fileStorage = (FileStorage) filesConverter.fileToDcat(jsonObjectFile);
-                        fileStorage.fileName = apiFileName;
-                        fileStorages.add(fileStorage);
-                    } catch (Exception e) {
-                        exceptions.put(apiFileName, e.fillInStackTrace().getMessage());
-                    }
+                boolean isSingleFile = apiSpecMap.size() == 1;
+                boolean isCatalogFile = apiFileName.contains(ConverterHelpClass.catalogFileName);
+
+                if(isSingleFile || isCatalogFile){
+                    addCatalog(jsonObjectFile, apiFileName, exceptions);
+                }
+                // Single file and non-catalog files produces FileStorage
+                if(isSingleFile || !isCatalogFile){
+                    addFileStorage(jsonObjectFile, apiFileName, exceptions);
                 }
             }
         }
@@ -214,38 +193,41 @@ public class Manager {
                 validationErrorsPerFileMap = e.getValidationResults();
             }
         }
-        StringBuilder exceptionResult = new StringBuilder();
 
-        // True if ApiDefinitionParser or Converter return errors
-        if (!exceptions.isEmpty()) {
-            exceptionResult.append("\n");
-            exceptions.forEach((key, value) -> exceptionResult.append(key).append(":\n").append(value).append("\n\n"));
+        String errorReport = errorReporter.buildErrorReport(exceptions, validationErrorsPerFileMap);
+
+        // If any errors, return report
+        if(!errorReport.isEmpty()){
+            result = "There are Errors in the following files: \n" + errorReport;
+            logger.error(result);
+            return result;
         }
 
-        // True if RDFWorker return errors
-        if (ValidationErrorStorage.getInstance().hasValidationErrors()) {
-            exceptionResult.append("\n");
-            validationErrorsPerFileMap.forEach((key, value) -> {
-                exceptionResult.append(key).append(":\n");
-
-                for (ValidationError validationError : value) {
-                    exceptionResult.append("Errortype: ").append(validationError.getErrorType()).append(" Description: ").append(validationError.getDescription()).append("\n");
-                }
-                exceptionResult.append("\n");
-            });
-        }
-
-        resetValidationErrors();
-
-        if (exceptionResult.length() > 0) {
-            exceptionResult.append("Check DCAT-AP-SE specification for info. https://docs.dataportal.se/dcat/sv/\n---------------------------------\n");
-            logger.error("There are Errors in the following files: \n" + exceptionResult);
-            return "There are Errors in the following files: \n" + exceptionResult;
-        }
         if (result.contains("RDF")) {
             printToFile(result, "dcat.rdf");
         }
         return result;
+    }
+
+    private void addCatalog(JSONObject json, String fileName, Map<String, String> exceptions) {
+        ConverterCatalog catalogConverter = new ConverterCatalog();
+        try {
+            catalog = (Catalog) catalogConverter.catalogToDcat(json);
+            catalog.fileName = fileName;
+        } catch (Exception e) {
+            exceptions.put(fileName, e.fillInStackTrace().getMessage());
+        }
+    }
+
+    private void addFileStorage(JSONObject json, String fileName, Map<String, String> exceptions) {
+        try {
+            ConverterFiles filesConverter = new ConverterFiles();
+            FileStorage fileStorage = (FileStorage) filesConverter.fileToDcat(json);
+            fileStorage.fileName = fileName;
+            fileStorages.add(fileStorage);
+        } catch (Exception e) {
+            exceptions.put(fileName, e.fillInStackTrace().getMessage());
+        }
     }
 
     private boolean validateFileExtension(String filename){

--- a/src/test/java/se/ams/dcatprocessor/ApplicationTest.java
+++ b/src/test/java/se/ams/dcatprocessor/ApplicationTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import se.ams.dcatprocessor.util.CliFlags;
+import se.ams.dcatprocessor.cli.CliFlags;
 
 
 public class ApplicationTest {

--- a/src/test/java/se/ams/dcatprocessor/cli/CliRunnerTest.java
+++ b/src/test/java/se/ams/dcatprocessor/cli/CliRunnerTest.java
@@ -15,7 +15,7 @@
  * along with dcat-ap-se-processor.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package se.ams.dcatprocessor;
+package se.ams.dcatprocessor.cli;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -32,6 +32,8 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.DefaultApplicationArguments;
 import org.springframework.context.ApplicationContext;
+
+import se.ams.dcatprocessor.processor.Manager;
 
 @ExtendWith(MockitoExtension.class)
 public class CliRunnerTest {

--- a/src/test/java/se/ams/dcatprocessor/controller/PreprocessorControllerRestTest.java
+++ b/src/test/java/se/ams/dcatprocessor/controller/PreprocessorControllerRestTest.java
@@ -15,7 +15,7 @@
  * along with dcat-ap-se-processor.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package se.ams.dcatprocessor;
+package se.ams.dcatprocessor.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -100,4 +100,3 @@ class PreprocessorControllerRestTest {
 		assertTrue(actual.length() > 500); //We get a .rdf file back but we don't care what it contains
 	}
 }
-

--- a/src/test/java/se/ams/dcatprocessor/converter/ConverterTest.java
+++ b/src/test/java/se/ams/dcatprocessor/converter/ConverterTest.java
@@ -1,0 +1,128 @@
+package se.ams.dcatprocessor.converter;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.eclipse.rdf4j.model.vocabulary.DCAT;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import se.ams.dcatprocessor.models.DataClass;
+import se.ams.dcatprocessor.models.DataSet;
+
+public class ConverterTest {
+
+    private Converter converter;
+
+    @BeforeEach
+    void setup(){
+        converter = new Converter();
+        Converter.deleteErrors();
+    }
+
+    @Test
+    void testThatAddLanguageValuesReturnsFalseWhenNoMatch() throws IOException {
+        boolean result = converter.addLanguageValues(getJSONObjectForTest(), "about", Optional.empty(), Optional.of(new DataClass()), "about");
+        assertFalse(result);
+    }
+
+    @Test
+    void testThatAddLanguageValuesSetsLanguageWithoutSubset() throws IOException{
+        String annotationName = "title";
+        String key = "dcterms:title";
+        Optional<String> subCat = Optional.empty();
+        Optional<DataClass> dataClass = Optional.empty();
+
+        boolean result = converter.addLanguageValues(getJSONObjectForTest(), annotationName, subCat, dataClass, key);
+
+        assertTrue(result);
+        assertTrue(converter.catalog.dcData.get(key + "-sv").contains("Svensk-titel"));
+        assertTrue(converter.catalog.dcData.get(key + "-en").contains("English-title"));
+    }
+
+   	@ParameterizedTest
+	@MethodSource("getDcatLocalNames")
+    void testThatAddLanguageValuesSetsLanguageWithSubset(String subCat) throws IOException{
+        String annotationName = "title";
+        String key = "dcterms:title";
+        DataClass dataClass = new DataClass();
+
+        boolean result = converter.addLanguageValues(getJSONObjectForTest(), annotationName, Optional.of(subCat), Optional.of(dataClass), key);
+
+        assertTrue(result);
+        assertTrue(dataClass.dcData.get(key).contains("sv¤Svensk-titel"));
+        assertTrue(dataClass.dcData.get(key).contains("en¤English-title"));
+    }
+
+    @Test
+    void testThatAddLanguageValuesSetsLanguageIfProvenace() throws IOException{
+        String key = DCTERMS.PROVENANCE.getLocalName();
+        String annotationName = "provenance";
+        Optional<String> subCat = Optional.of(DCAT.DATASET.getLocalName());
+        DataSet dataSet = new DataSet();
+
+        boolean result = converter.addLanguageValues(getJSONObjectForTest(), annotationName, subCat, Optional.of(dataSet), key);
+
+        assertTrue(result);
+        assertTrue(dataSet.provenances.stream()
+            .anyMatch(p -> p.dcData.get("dcterms:description").contains("sv¤Källa SCB")));
+        assertTrue(dataSet.provenances.stream()
+            .anyMatch(p -> p.dcData.get("dcterms:description").contains("en¤Source SCB")));
+    }
+
+    @Test
+    void testThatAddMandatoryErrorAddsMessageWithSubCat() {
+        converter.addMandatoryError("title", Optional.of("dataset"));
+        assertTrue(Converter.errors.contains("Errormessage: title in dataset is Mandatory"));
+    }
+
+    @Test
+    void testThatAddMandatoryErrorAddsMessageWithoutSubCat() {
+        converter.addMandatoryError("title", Optional.empty());
+        assertTrue(Converter.errors.contains("Errormessage: title is Mandatory"));
+    }
+
+    @Test
+    void testThatIsKeyMandatoryReturnsTrueWhenKeyExists() {
+        converter.jsonObjectMandatoryDcat = new JSONObject("{\"title\": true}");
+        assertTrue(converter.isKeyMandatory("title", Optional.empty()));
+    }
+
+    @Test
+    void testThatIsKeyMandatoryReturnsTrueWhenCompositeKeyExists() {
+        converter.jsonObjectMandatoryDcat = new JSONObject("{\"dataset-title\": true}");
+        assertTrue(converter.isKeyMandatory("title", Optional.of("dataset")));
+    }
+
+    @Test
+    void testThatIsKeyMandatoryReturnsFalseWhenKeyMissing() {
+        converter.jsonObjectMandatoryDcat = new JSONObject("{}");
+        assertFalse(converter.isKeyMandatory("title", Optional.empty()));
+    }
+
+    private JSONObject getJSONObjectForTest(){
+        return new JSONObject("""
+        {
+            "title-sv": "Svensk-titel",
+            "title-en": "English-title",
+            "provenance-sv": "Källa SCB",
+            "provenance-en": "Source SCB"
+        }
+        """);
+    }
+
+    private static String[] getDcatLocalNames(){
+        return new String[]{
+            DCAT.DATASET.getLocalName(),
+            DCAT.DISTRIBUTION.getLocalName(), 
+            DCAT.CATALOG.getLocalName(),
+        };
+    }
+}

--- a/src/test/java/se/ams/dcatprocessor/parser/ApiDefinitionParserTest.java
+++ b/src/test/java/se/ams/dcatprocessor/parser/ApiDefinitionParserTest.java
@@ -19,11 +19,15 @@ package se.ams.dcatprocessor.parser;
 
 import org.junit.jupiter.api.Test;
 
+import se.ams.dcatprocessor.rdf.DcatException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 
 public class ApiDefinitionParserTest {
 
@@ -185,17 +189,25 @@ public class ApiDefinitionParserTest {
             "}";
 
     private static String ramlResult = "{\"(dcat-dataset 1)\":{\"title-sv\":\"Datamängd 1\",\"about\":\"https://www.example.se/result.rdf#dataset1\",\"description\":\"Exempel beskrivning 1\",\"publisher\":{\"name\":\"Redpill Linpro AB 1\"}},\"dcat-dataservice\":{\"properties\":{\"contactPoint\":{\"landingPage\":\"string\",\"adress\":\"string\",\"type\":\"string\",\"license\":\"string\",\"phone\":\"string\",\"name\":\"string\",\"theme\":\"string\",\"conformsTo\":\"string\",\"accessRights\":\"string\",\"page\":\"string\",\"keyword\":\"string\",\"servesDataset\":\"string\",\"email\":\"string\"},\"endpointURL\":\"string\",\"description\":\"string\",\"publisher\":{\"name\":\"string\",\"type\":\"string\",\"mbox\":\"string\",\"homepage\":\"string\"},\"title\":\"string\",\"endpointDescription\":\"string\"}},\"description\":\"Annotation exempel api är ett påhittat api som använder sig av annotations för att skapa metadata för DCAT-AP-SE.\",\"dcat-dataset\":{\"properties\":{\"creator\":\"string\",\"contactPoint\":{\"phone\":\"string\",\"name\":\"string\",\"adress\":\"string\",\"type\":\"string\",\"email\":\"string\"},\"description\":\"string\",\"publisher\":{\"name\":\"string\",\"type\":\"string\",\"mbox\":\"string\",\"homepage\":\"string\"},\"location\":{\"centroid\":\"string\",\"bbox\":\"string\",\"geometry\":\"string\"},\"title\":\"string\",\"distribution\":{\"byteSize\":\"string\",\"accessURL\":\"string\",\"downloadURL\":\"string\",\"description\":\"string\",\"language\":\"string\",\"availability\":\"string\",\"title\":\"string\",\"temporalResolution\":\"string\",\"accessService\":\"string\",\"spatialResolutionInMeters\":\"string\",\"rights\":\"string\",\"checksum\":\"string\",\"modified\":\"string\",\"theme\":\"string\",\"issued\":\"string\",\"keyword\":\"string\",\"identifier\":\"string\",\"adms\":\"string\",\"landingPage\":\"string\",\"format\":\"string\",\"license\":\"string\",\"page\":\"string\",\"conformsTo\":\"string\",\"belongsTo\":\"string\",\"status\":\"string\"},\"qualifiedAttribution\":\"string\",\"temporal\":{\"offers\":\"string\",\"endDate\":\"string\",\"hasVersion\":\"string\",\"versionInfo\":\"string\",\"source\":\"string\",\"relation\":\"string\",\"isReferencedBy\":\"string\",\"provenance\":\"string\",\"temporalResolution\":\"string\",\"spatialResolutionInMeters\":\"string\",\"qualifiedRelation\":\"string\",\"accrualPeriodicity\":\"string\",\"versionNotes\":\"string\",\"accessRights\":\"string\",\"isVersionOf\":\"string\",\"page\":\"string\",\"startDate\":\"string\"}}},\"title\":\"Annotation exempel api\",\"version\":\"1.0.0\",\"annotationTypes\":null,\"dcat-catalog\":{\"properties\":{\"themeTaxonomy\":\"string\",\"hasPart\":\"string\",\"about\":\"string\",\"description\":\"string\",\"language\":\"string\",\"title\":\"string\",\"isPartOf\":\"string\",\"license\":\"string\",\"rights\":\"string\",\"publisher\":{\"name\":\"string\",\"type\":\"string\",\"mbox\":\"string\",\"homepage\":\"string\"},\"modified\":\"string\",\"location\":{\"centroid\":\"string\",\"bbox\":\"string\",\"geometry\":\"string\"},\"issued\":\"string\",\"homepage\":\"string\"}},\"(dcat-catalog)\":{\"title-sv\":\"Annotation exempel RAML 1.0\",\"license\":\"https://www.apache.org/licenses/LICENSE-2.0\",\"title-en\":\"Annotation example RAML 1.0\",\"about\":\"www.af.se\",\"description\":\"Annotation exempel från arbetsförmedlingen\",\"publisher\":{\"name\":\"Redpill Linpro AB Catalog\"},\"dataset\":\"https://www.example.se/result.rdf#dataset1\"}}";
-    private static String jsonresult = "{\"dcat-dataset\":{\"title-sv\":\"Datamängd 1\",\"about\":\"https://www.example.se/result.rdf#dataset1\",\"publisher\":{\"about\":\"https://www.example.se/result.rdf#publisher\",\"name\":\"Redpill Linpro AB 1\"},\"description-sv\":\"Exempel beskrivning 1\"},\"dcat-catalog\":{\"title-sv\":\"Annotation exempel RAML 1.0\",\"license\":\"https://www.apache.org/licenses/LICENSE-2.0\",\"title-en\":\"Annotation example RAML 1.0\",\"about\":\"https://www.af.se\",\"publisher\":{\"about\":\"https://www.example.se/result.rdf#publisher\",\"name\":\"Redpill Linpro AB Catalog\"},\"description-sv\":\"Annotation exempel från arbetsförmedlingen\"}}";
+    private static String jsonResult = "{\"dcat-dataset\":{\"title-sv\":\"Datamängd 1\",\"about\":\"https://www.example.se/result.rdf#dataset1\",\"publisher\":{\"about\":\"https://www.example.se/result.rdf#publisher\",\"name\":\"Redpill Linpro AB 1\"},\"description-sv\":\"Exempel beskrivning 1\"},\"dcat-catalog\":{\"title-sv\":\"Annotation exempel RAML 1.0\",\"license\":\"https://www.apache.org/licenses/LICENSE-2.0\",\"title-en\":\"Annotation example RAML 1.0\",\"about\":\"https://www.af.se\",\"publisher\":{\"about\":\"https://www.example.se/result.rdf#publisher\",\"name\":\"Redpill Linpro AB Catalog\"},\"description-sv\":\"Annotation exempel från arbetsförmedlingen\"}}";
+
+    @Test
+    void testThatUnsupportedFormatThrowsException() {
+        String invalid = "invalid api spec"; 
+        assertThrows(DcatException.class, () -> ApiDefinitionParser.getApiJsonString(invalid));
+    }
 
     @Test
     void testMandatoryRamlApi() throws JSONException, IOException {
-        String result = ApiDefinitionParser.getApiJsonString(ramlApi).toString();
-        assertEquals(result, ramlResult);
+        JSONObject actual = ApiDefinitionParser.getApiJsonString(ramlApi);
+        JSONObject expected = new JSONObject(ramlResult);
+        assertEquals(expected.toMap(), actual.toMap());
     }
 
     @Test
     void testMandatoryJsonApi() throws JSONException, IOException {
-        String result = ApiDefinitionParser.getApiJsonString(jsonApi).toString();
-        assertEquals(result, jsonresult);
+        JSONObject actual = ApiDefinitionParser.getApiJsonString(jsonApi);
+        JSONObject expected = new JSONObject(jsonResult);
+        assertEquals(expected.toMap(), actual.toMap());
     }
 }

--- a/src/test/java/se/ams/dcatprocessor/processor/ErrorReporterTest.java
+++ b/src/test/java/se/ams/dcatprocessor/processor/ErrorReporterTest.java
@@ -1,0 +1,79 @@
+package se.ams.dcatprocessor.processor;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import se.ams.dcatprocessor.rdf.validate.ValidationError;
+import se.ams.dcatprocessor.rdf.validate.ValidationError.ErrorType;
+
+public class ErrorReporterTest {
+
+    private ErrorReporter errorReporter;
+    
+    @BeforeEach
+    void setUp() {
+        errorReporter = new ErrorReporter();
+    }
+
+    @Test
+    void testThatBuildErrorReportWithNoErrorsReturnsEmpty() {
+        String report = errorReporter.buildErrorReport(Map.of(), Map.of());
+        assertTrue(report.isEmpty());
+    }
+
+    @Test
+    void testThatBuildErrorReportContainsDocsUrlWhenErrorsExist() {
+        String report = errorReporter.buildErrorReport(Map.of("api.yaml", "Invalid format"), Map.of());
+        assertTrue(report.contains("https://docs.dataportal.se/dcat/sv/"));
+    }
+
+    @Test
+    void testThatBuildErrorReportReportsExceptionsErrors() {
+        String filename = "api.yaml";
+        String msg = "Invalid format";
+
+        String report = errorReporter.buildErrorReport(Map.of(filename, msg), Map.of());
+
+        assertTrue(report.contains(msg));
+        assertTrue(report.contains(filename));
+    }
+
+    @Test
+    void testThatBuildErrorReportReportsValidationErrors() {
+        String value = "About";
+        String filename = "catalog.yaml";
+        ValidationError error = new ValidationError(ErrorType.DUPLICATE_URI_BETWEEN_FILES, new String[]{filename}, value);
+        Map<String, List<ValidationError>> validationErrors = Map.of(filename, List.of(error));
+
+        String report = errorReporter.buildErrorReport(Map.of(), validationErrors);
+
+        assertTrue(report.contains(value));
+        assertTrue(report.contains(filename));
+        assertTrue(report.contains(ErrorType.DUPLICATE_URI_BETWEEN_FILES.toString()));
+    }
+
+    @Test
+    void testThatBuildErrorReportReportsBothErrorTypes() {
+        String file1 = "catalog.yaml";
+        String file2 = "api.yaml";
+        String field = "About";
+        String errorMsg = "Invalid format";
+
+        ValidationError validationError = new ValidationError(ErrorType.DUPLICATE_URI_BETWEEN_FILES, new String[]{file1}, field);
+        Map<String, List<ValidationError>> validationErrors = Map.of(file1, List.of(validationError));
+        Map<String, String> exceptions = Map.of(file2, errorMsg);
+
+        String report = errorReporter.buildErrorReport(exceptions, validationErrors);
+
+        assertTrue(report.contains(file1));
+        assertTrue(report.contains(field));
+        assertTrue(report.contains(ErrorType.DUPLICATE_URI_BETWEEN_FILES.toString()));
+        assertTrue(report.contains(file2));
+        assertTrue(report.contains(errorMsg));
+    }
+}

--- a/src/test/java/se/ams/dcatprocessor/processor/ManagerTest.java
+++ b/src/test/java/se/ams/dcatprocessor/processor/ManagerTest.java
@@ -15,7 +15,7 @@
  * along with dcat-ap-se-processor.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package se.ams.dcatprocessor;
+package se.ams.dcatprocessor.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;


### PR DESCRIPTION
## Refactoring part 2

Refactoring with the intent to make the codebase more readable and separation of concern without changing the logic or implemented patterns. The biggest changes are made in the Converter class and its extending classes. 

- Moved several .java files from root to folders for better structure in the project. Changes are mirrored in the test section.
- Removed unused Object parameter from constructor in Result (model used in UI), renamed class variable description to result.
- New class ErrorReporter for composing error reports, and minor refactoring in Manager to use it. Unittest for new class.
- Refactoring of Converter and the extending classes ConverterCatalog, ConverterDataService, ConverterDataSet, ConverterDistribution, ConverterFiles.
  - move and rename loopData() from extending classes
  - simplify processToDcat() by breaking out logic to separate methods
  - cache jsonLanguageFile for improved performance
  - simplified and renamed loopLanguage() and loopObject()
  - unittests for Converter methods: addLanguageValues(), addMandatoryError(), isKeyMandatory()
- Refactoring of ApiDefinitionParser
  - getApiJsonString() simplified and without the need for stream
  - getFileApiYamlRaml() now handles json converting without saving temp file to disk (not thread safe)
  - new unittest and minor improvement on existing tests


Fixes #46

### Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
