### PR TITLE
Refactor/59 improve maintainability

### DIFF
--- a/src/main/java/se/ams/dcatprocessor/converter/Converter.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/Converter.java
@@ -26,18 +26,6 @@ public class Converter {
         errors.clear();
     }
 
-    /*
-     * Takes one specFile for a Catalog and creates a Catalog Object */
-    public DataClass catalogToDcat(JSONObject apiSpec) throws Exception {
-        return catalog;
-    }
-
-    /*
-     * Takes one specFile for a Api and creates an Object with ApiSpec tags, DataSet, DataService, Distribution etc. */
-    public DataClass fileToDcat(JSONObject apiSpec) throws Exception {
-        return fileHandler;
-    }
-
     void processToDcat(JSONObject subConvert, JSONObject file, Optional<String> subCat, Optional<DataClass> preData, Optional<DataClass> preDist) throws Exception {
     }
 

--- a/src/main/java/se/ams/dcatprocessor/converter/ConverterCatalog.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/ConverterCatalog.java
@@ -7,16 +7,19 @@ package se.ams.dcatprocessor.converter;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.eclipse.rdf4j.model.vocabulary.*;
 import org.json.JSONObject;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
 import se.ams.dcatprocessor.models.*;
 
 import java.io.IOException;
 import java.util.*;
 
-
+@Component
+@Scope("prototype")
 public class ConverterCatalog extends Converter {
 
     /* Takes one specFile for a Catalog and creates a Catalog Object */
-    @Override
     public DataClass catalogToDcat(JSONObject apiSpec) throws Exception {
         setConvertAndMandatoryFile(ConverterHelpClass.uriToDcatCatalog);
         processToDcat(orgConvert, apiSpec, Optional.empty(), Optional.empty(), Optional.empty());
@@ -133,10 +136,10 @@ public class ConverterCatalog extends Converter {
             jsonSupportiveDcat = getSupportiveFile(key, subCat.get());
 
         String[] splitValue = value.split(";");
+
         for (String s : splitValue) {
-            String mapValue = s;
+            String mapValue = s.trim();
             if (jsonSupportiveDcat != null) {
-                mapValue = mapValue.trim();
                 if (jsonSupportiveDcat.has(mapValue)) {
                     mapValue = (String) ((JSONObject) (jsonSupportiveDcat.get(mapValue))).get("url");
                 } else if (!mapValue.contains("http://") && !key.contains("format")) {
@@ -144,7 +147,6 @@ public class ConverterCatalog extends Converter {
                 }
             }
             if (ConverterHelpClass.tagWithUri.contains(key)) {
-                mapValue = mapValue.trim();
                 if (!(mapValue.contains("http"))) {
                     mapValue = "http://" + mapValue;
                 }
@@ -153,7 +155,6 @@ public class ConverterCatalog extends Converter {
                 key = "dcterms:" + key;
             }
             if (ConverterHelpClass.tagWithUriMail.contains(key)) {
-                mapValue = mapValue.trim();
                 mapValue = "mailTo:" + mapValue;
             }
             valueMap.put(key, mapValue);

--- a/src/main/java/se/ams/dcatprocessor/converter/ConverterDataService.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/ConverterDataService.java
@@ -9,6 +9,9 @@ import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.VCARD4;
 import org.json.JSONObject;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
 import se.ams.dcatprocessor.models.ConverterHelpClass;
 import se.ams.dcatprocessor.models.DataClass;
 import se.ams.dcatprocessor.models.DataService;
@@ -16,7 +19,8 @@ import se.ams.dcatprocessor.models.Organization;
 
 import java.util.Optional;
 
-
+@Component
+@Scope("prototype")
 public class ConverterDataService extends Converter {
 
     /*

--- a/src/main/java/se/ams/dcatprocessor/converter/ConverterDataSet.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/ConverterDataSet.java
@@ -6,12 +6,16 @@ package se.ams.dcatprocessor.converter;
 
 import org.eclipse.rdf4j.model.vocabulary.*;
 import org.json.JSONObject;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
 import se.ams.dcatprocessor.models.*;
 import se.ams.dcatprocessor.rdf.namespace.SCHEMA;
 
 import java.util.Optional;
 
-
+@Component
+@Scope("prototype")
 public class ConverterDataSet extends Converter {
 
     /* Process the spec to find elements for dcat-ap-se and add them to an Object to return */

--- a/src/main/java/se/ams/dcatprocessor/converter/ConverterDatasetSeries.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/ConverterDatasetSeries.java
@@ -6,11 +6,15 @@ package se.ams.dcatprocessor.converter;
 
 import org.eclipse.rdf4j.model.vocabulary.*;
 import org.json.JSONObject;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 import se.ams.dcatprocessor.models.*;
 
 import java.util.Optional;
 
+@Component
+@Scope("prototype")
 public class ConverterDatasetSeries extends Converter {
 
     @Override

--- a/src/main/java/se/ams/dcatprocessor/converter/ConverterDistribution.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/ConverterDistribution.java
@@ -9,12 +9,16 @@ import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.VCARD4;
 import org.json.JSONObject;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
 import se.ams.dcatprocessor.models.*;
 import se.ams.dcatprocessor.rdf.namespace.SPDX;
 
 import java.util.Optional;
 
-
+@Component
+@Scope("prototype")
 public class ConverterDistribution extends Converter {
 
     /* Process the spec to find elements for dcat-ap-se and add them to an Object to return */

--- a/src/main/java/se/ams/dcatprocessor/converter/ConverterFiles.java
+++ b/src/main/java/se/ams/dcatprocessor/converter/ConverterFiles.java
@@ -5,22 +5,37 @@
 package se.ams.dcatprocessor.converter;
 
 import org.eclipse.rdf4j.model.vocabulary.DCAT;
-import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
-import org.eclipse.rdf4j.model.vocabulary.FOAF;
-import org.eclipse.rdf4j.model.vocabulary.VCARD4;
 import org.json.JSONObject;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
 import se.ams.dcatprocessor.models.*;
 
 import java.util.*;
 
+@Component
+@Scope("prototype")
 public class ConverterFiles extends Converter {
-
-    /* Takes one specFile for a Api and creates an Object with ApiSpec tags, DataSet, DataService, Distribution etc. */
-    @Override
+    
+    private ConverterDatasetSeries converterDatasetSeries;
+    private ConverterDataSet convertDataSet;
+    private ConverterDataService convertDataService;
+    
+    public ConverterFiles(
+        ConverterDatasetSeries converterDatasetSeries, 
+        ConverterDataSet convertDataSet, 
+        ConverterDataService convertDataService
+    ) {
+        this.converterDatasetSeries = converterDatasetSeries;
+        this.convertDataSet = convertDataSet;
+        this.convertDataService = convertDataService;
+    }
+    
+    /* Takes one specFile for a Api and creates an Object with ApiSpec tags, DataSet, DataService and DatasetSeries. */
     public DataClass fileToDcat(JSONObject apiSpec) throws Exception {
         setConvertAndMandatoryFile(ConverterHelpClass.uriToDcat);
-        processToDcat(orgConvert, apiSpec, Optional.empty(), Optional.empty(), Optional.empty());
-
+        primaryClassesToDcat(apiSpec);
+        
         if (errors.size() > 0) {
             StringBuilder errorResult = new StringBuilder();
             for (String error : errors) {
@@ -30,122 +45,50 @@ public class ConverterFiles extends Converter {
         }
         return fileHandler;
     }
+    
+    /*
+     * This method maps no fields of its own. It runs only at the top level of
+     * an API spec and (if pressent) creates the primary-class blocks:
+     * - dcat-datasetseries
+     * - dcat-dataset
+     * - dcat-dataservice
+     */
+    void primaryClassesToDcat(JSONObject file) throws Exception {
 
-    /* Process the spec to find elements for dcat-ap-se and add them to an Object to return */
-    @Override
-    void processToDcat(JSONObject subConvert, JSONObject file, Optional<String> subCat, Optional<DataClass> preData, Optional<DataClass> preDist) throws Exception {
-        DataSet dataSet = new DataSet();
-        DataService dataService = new DataService();
-        Distribution distribution = new Distribution();
-        Organization organizationLocal = new Organization();
-        DataClass dataClassLocal = new DataClass();
-
-        for (String key : subConvert.keySet()) {
-
-            if (key.equals(ConverterHelpClass.toDcatString) && subCat.isPresent()) {
-                continue;
-            }
+        for (String key : orgConvert.keySet()) {
 
             // Get tag-name for api-spec
-            String annotationName = subConvert.getJSONObject(key).getString(ConverterHelpClass.toDcatString);
-
-            // Check if tag is Mandatory
-            boolean isMandatory = isKeyMandatory(key, subCat);
+            String annotationName = orgConvert.getJSONObject(key).getString(ConverterHelpClass.toDcatString);
+            boolean isMandatory = isKeyMandatory(key,  Optional.empty());
             
             // Do if key is DATASETSERIES
             if (key.equals(DCAT.DATASET_SERIES.getLocalName())) { 
-                ConverterDatasetSeries converterDatasetSeries = new ConverterDatasetSeries();
                 converterDatasetSeries.orgConvert = orgConvert;
                 converterDatasetSeries.fileHandler = fileHandler;
                 converterDatasetSeries.jsonObjectMandatoryDcat = jsonObjectMandatoryDcat;
+
+                // builds the complete DatasetSeries block with every tag and nested objects
                 converterDatasetSeries.createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
             }
             // Do if key is DATASET
-            else if (key.contains(DCAT.DATASET.getLocalName())) {
-                ConverterDataSet convertDataSet = new ConverterDataSet();
+            else if (key.equals(DCAT.DATASET.getLocalName())) {
                 convertDataSet.orgConvert = orgConvert;
                 convertDataSet.jsonObjectMandatoryDcat = jsonObjectMandatoryDcat;
                 convertDataSet.fileHandler = fileHandler;
-                convertDataSet.createSubset(file, key, annotationName, Optional.of(dataSet), Optional.empty(), isMandatory);
+
+                // builds the complete Dataset block with every tag and nested objects
+                convertDataSet.createSubset(file, key, annotationName, Optional.of(new DataSet()), Optional.empty(), isMandatory);
             }
-            // Do if key is LICENSE_DOCUMENT
-            else if (key.equals(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
-                if (subCat.isPresent()) {
-                    if (subCat.get().equals(DCAT.DATA_SERVICE.getLocalName())) {
-                        createSubset(file, key, annotationName, Optional.of(dataService), Optional.empty(), isMandatory);
-                    } else if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                        createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
-                    } else {
-                        createSubset(file, key, annotationName, Optional.empty(), Optional.of(distribution), isMandatory);
-                    }
-                } else {
-                    createSubset(file, key, annotationName, preData, Optional.of(distribution), isMandatory);
-                }
-            }
+
             // Do if key is DATASERVICE
-            else if (key.contains(DCAT.DATA_SERVICE.getLocalName())) {
-                ConverterDataService convertDataService = new ConverterDataService();
+            else if (key.equals(DCAT.DATA_SERVICE.getLocalName())) {
                 convertDataService.orgConvert = orgConvert;
                 convertDataService.jsonObjectMandatoryDcat = jsonObjectMandatoryDcat;
                 convertDataService.fileHandler = fileHandler;
-                convertDataService.createSubset(file, key, annotationName, Optional.of(dataService), Optional.empty(), isMandatory);
-            }
-            // Do if key is A Nested Object
-            else if (ConverterHelpClass.isNestedObjects(key)) {
-                if (subCat.isEmpty()) {
-                    createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
-                } else if (subCat.get().equals(DCTERMS.RIGHTS_STATEMENT.getLocalName())) {
-                    createSubset(file, key, annotationName, Optional.of(dataClassLocal), Optional.empty(), isMandatory);
-                } else {
-                    createSubset(file, key, annotationName, Optional.empty(), Optional.empty(), isMandatory);
-                }
-            }
-            
-            // Checks for language strings to add them correctly
-            else {
-                boolean hasLanguages = false;
-                if (subCat.isPresent()) {
-                    if (ConverterHelpClass.isNestedLanguageObjects(subCat.get())) {
-                        hasLanguages = addLanguageValues(file, annotationName, subCat, Optional.of(dataClassLocal), key);
-                    }
-                }
-                if (!hasLanguages) {
-                    if (key.equals(VCARD4.ADDRESS.getLocalName())) {
-                        handleAddress(file, key, annotationName, organizationLocal, subCat);
-                    } else if (file.has(annotationName)) {
-                        String value = String.valueOf(file.get(annotationName));
-                        if (subCat.isPresent()) {
-                            if (subCat.get().contains(DCAT.CONTACT_POINT.getLocalName())) {
-                                addValues(organizationLocal, value, key, subCat);
-                            } else if (ConverterHelpClass.isNestedObjects(subCat.get())) {
-                                addValues(dataClassLocal, value, key, subCat);
-                            }
-                        }
-                    } else if (isMandatory) {
-                        addMandatoryError(annotationName, subCat);
-                    }
-                }
-            }
-        }
-        if (subCat.isPresent()) {
-            attachDataToParent(subCat, preData, dataClassLocal);
-        }
-    }
 
-    
-    // Attaches the locally built dataClassLocal to the correct field on preData
-    private void attachDataToParent(Optional<String> subCat, Optional<DataClass> preData, DataClass dataClassLocal) {
-        if (preData.isEmpty()) return;
-        
-        String subCatValue = subCat.get();
-        DataClass parent = preData.get();
-        
-        if (subCatValue.contains(DCTERMS.PUBLISHER.getLocalName())) {
-            parent.agent = dataClassLocal;
-        } else if (subCatValue.contains(DCTERMS.LICENSE_DOCUMENT.getLocalName())) {
-            parent.licenseDocuments.add(dataClassLocal);
-        } else if (subCatValue.contains(FOAF.DOCUMENT.getLocalName())) {
-            parent.documents.add(dataClassLocal);
-        }
+                // builds the complete DataService block with every tag and nested objects
+                convertDataService.createSubset(file, key, annotationName, Optional.of(new DataService()), Optional.empty(), isMandatory);
+            }
+        }  
     }
 }

--- a/src/main/java/se/ams/dcatprocessor/parser/ApiDefinitionParser.java
+++ b/src/main/java/se/ams/dcatprocessor/parser/ApiDefinitionParser.java
@@ -36,13 +36,13 @@ public class ApiDefinitionParser {
         JSONObject jsonObjectFile;
         try {
             jsonObjectFile = new JSONObject(apiJsonString);
+            
+            if (jsonObjectFile.has("info")) {
+                jsonObjectFile = jsonObjectFile.getJSONObject("info");
+                jsonObjectFile = jsonObjectFile.getJSONObject("x-dcat");
+            }
         } catch (JSONException e) {
             throw new DcatException("Failed to parse JSON: " + e.getMessage());
-        }
-
-        if (jsonObjectFile.has("info")) {
-            jsonObjectFile = jsonObjectFile.getJSONObject("info");
-            jsonObjectFile = jsonObjectFile.getJSONObject("x-dcat");
         }
         return jsonObjectFile;
     }

--- a/src/main/java/se/ams/dcatprocessor/processor/ErrorReporter.java
+++ b/src/main/java/se/ams/dcatprocessor/processor/ErrorReporter.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Component;
-
 import se.ams.dcatprocessor.rdf.validate.ValidationError;
 
 @Component
@@ -17,33 +16,37 @@ public class ErrorReporter {
     private static final String DOCS_URL = "https://docs.dataportal.se/dcat/sv/";
 
     public String buildErrorReport(Map<String, String> exceptions, Map<String, List<ValidationError>> validationErrors) {
-        StringBuilder errors = new StringBuilder();
         StringBuilder report = new StringBuilder();
 
-        // Errors from ApiDefinitionParser or Converters
+        // Errors from ApiDefinitionParser, Converters or general errors
         if (!exceptions.isEmpty()) {
-            errors.append("\n");
-            exceptions.forEach((key, value) -> errors.append(key).append(":\n").append(value).append("\n\n"));
+            report.append("ERROR - Failed to process API specification\n");
+            report.append("-------------------------------------------\n");
+            report.append("\n");
+
+            exceptions.forEach((key, value) -> {
+                report.append(key).append(":\n").append(value).append("\n\n");  
+            });
         }
 
         // Errors from RDFWorker
-        if (!validationErrors.isEmpty()) {
-            errors.append("\n");
+        else if (!validationErrors.isEmpty()) {
+            report.append("There are Errors in the following files:\n");
+            report.append("Check DCAT-AP-SE specification for info\n");
+            report.append(DOCS_URL + "\n");
+            report.append("---------------------------------------\n");
+
+            report.append("\n");
             validationErrors.forEach((key, value) -> {
-                errors.append(key).append(":\n");
+                report.append(key).append(":\n");
                 for (ValidationError error : value) {
-                    errors.append("Errortype: ").append(error.getErrorType())
-                          .append(" Description: ").append(error.getDescription()).append("\n");
+                    report.append("Errortype: ").append(error.getErrorType());
+                    report.append(" Description: ").append(error.getDescription() + "\n");
                 }
-                errors.append("\n");
+                report.append("\n");
             });
         }
-        
-        if(!errors.isEmpty()){
-            report.append("Check DCAT-AP-SE specification for info. " + DOCS_URL + "\n---------------------------------\n");
-            report.append(errors);
-        }
-        
+   
         return report.toString();
     }
 }

--- a/src/main/java/se/ams/dcatprocessor/processor/Manager.java
+++ b/src/main/java/se/ams/dcatprocessor/processor/Manager.java
@@ -40,17 +40,26 @@ import java.util.*;
 public class Manager {
 
     private final ObjectProvider<RDFWorker> rdfWorkerProvider;
-    private final ErrorReporter errorReporter; 
+    private final ErrorReporter errorReporter;
+
+    private final ObjectProvider<ConverterFiles> converterFilesProvider;
+    private final ObjectProvider<ConverterCatalog> converterCatalogProvider;
 
     private static final Logger logger = LoggerFactory.getLogger(Manager.class);
     
     Catalog catalog = new Catalog();
     List<FileStorage> fileStorages = new ArrayList<>();
 
-    
-    public Manager(ObjectProvider<RDFWorker> rdfWorkerProvider, ErrorReporter errorReporter){
+    public Manager(
+        ObjectProvider<RDFWorker> rdfWorkerProvider,
+        ErrorReporter errorReporter,
+        ObjectProvider<ConverterFiles> converterFilesProvider,
+        ObjectProvider<ConverterCatalog> converterCatalogProvider
+    ) {
         this.rdfWorkerProvider = rdfWorkerProvider;
         this.errorReporter = errorReporter;
+        this.converterFilesProvider = converterFilesProvider;
+        this.converterCatalogProvider = converterCatalogProvider;
     }
 
     public String createDcatFromDirectory(String dir) throws Exception {
@@ -174,10 +183,16 @@ public class Manager {
                 result = rdfWorker.createDcatFile(catalog, fileStorages);
             }
         } catch (DcatException e) {
-            if (e.getValidationResults().isEmpty()) {
+            // holds validation errors
+            validationErrorsPerFileMap = e.getValidationResults();
+
+            // system exceptions
+            if(validationErrorsPerFileMap == null){
+                exceptions.put("Error", e.getMessage());
+            }
+            // RDFWorker exceptions
+            else if (e.getValidationResults().isEmpty()) {
                 exceptions.put("RDFWorker", e.fillInStackTrace().getMessage());
-            } else {
-                validationErrorsPerFileMap = e.getValidationResults();
             }
         }
 
@@ -185,9 +200,8 @@ public class Manager {
 
         // If any errors, return report
         if(!errorReport.isEmpty()){
-            result = "There are Errors in the following files: \n" + errorReport;
-            logger.error(result);
-            return result;
+            logger.error(errorReport);
+            return errorReport;
         }
 
         if (result.contains("RDF")) {
@@ -197,9 +211,9 @@ public class Manager {
     }
 
     private void addCatalog(JSONObject json, String fileName, Map<String, String> exceptions) {
-        ConverterCatalog catalogConverter = new ConverterCatalog();
         try {
-            catalog = (Catalog) catalogConverter.catalogToDcat(json);
+            ConverterCatalog converterCatalog = converterCatalogProvider.getObject();
+            catalog = (Catalog) converterCatalog.catalogToDcat(json);
             catalog.fileName = fileName;
         } catch (Exception e) {
             exceptions.put(fileName, e.fillInStackTrace().getMessage());
@@ -208,8 +222,8 @@ public class Manager {
 
     private void addFileStorage(JSONObject json, String fileName, Map<String, String> exceptions) {
         try {
-            ConverterFiles filesConverter = new ConverterFiles();
-            FileStorage fileStorage = (FileStorage) filesConverter.fileToDcat(json);
+            ConverterFiles converterFiles = converterFilesProvider.getObject();
+            FileStorage fileStorage = (FileStorage) converterFiles.fileToDcat(json);
             fileStorage.fileName = fileName;
             fileStorages.add(fileStorage);
         } catch (Exception e) {

--- a/src/main/java/se/ams/dcatprocessor/rdf/RDFWorker.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/RDFWorker.java
@@ -748,12 +748,9 @@ public class RDFWorker {
 		return false;
 	}
 	
-	//TODO: Improve this and remove hardcoded value
-	//Constants for multiple use
-	private final String VCARD_HAS_VALUE = "vcard:hasValue";
-	
 	private boolean isPhoneValue(String key) {
-		return key.equals(VCARD_HAS_VALUE);
+		String vcardHasValue = VCARD4.PREFIX + ":" + VCARD4.HAS_VALUE.getLocalName();
+		return key.equals(vcardHasValue);
 	}
 
 	/**

--- a/src/main/java/se/ams/dcatprocessor/rdf/validate/CardinalityValidator.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/validate/CardinalityValidator.java
@@ -43,9 +43,9 @@ public class CardinalityValidator {
 	 * Compares the inputvalues with the DCAT-AP-SE Specification and throws exception if
 	 * values are not included in the specification or if any value occurs more frequently than allowed
 	 * in the specification
-	 * @param dcatClass //TODO describe
+	 * @param dcatClass - The DCAT class to validate against (e.g., Dataset, Catalog, Distribution).
 	 * @param values - The input values to check
-	 * @param checkedElsewhere //TODO describe
+	 * @param checkedElsewhere - A list of property URIs (e.g., "dcterms:publisher") that have already been validated
 	 * @throws DcatException - Is thrown if there is a disconformity
 	 */
 	public boolean validate(DcatClass dcatClass, MultiValuedMap<String, String> values, List<String> checkedElsewhere) {

--- a/src/main/java/se/ams/dcatprocessor/rdf/validate/SingleInputValidator.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/validate/SingleInputValidator.java
@@ -61,9 +61,6 @@ public class SingleInputValidator {
 	private static String ERROR_KEY_OR_VALUE_IS_NULL = "Error validating type: Input X is null";
 	private static String ERROR_NO_CORRESPONDING_INPUT_TYPE = "Error validating type: Key X is not defined";
 	
-	//Predefined frequentry used string
-	private final String TEL_PREFIX = "tel:";
-	
 	/**
 	 * Checks if a value has the correct format according to the InputType definition(regex) mapped to the key
 	 * @param key - The key
@@ -115,21 +112,6 @@ public class SingleInputValidator {
 				return true;
 			}
 			
-			//TODO: Write a regex for this
-			/**
-			 * Special case for phonenumer...my BAD
-			 * 
-			 */
-			if(inputType.equals(InputType.PHONENUMBER)) {
-				if(value.contains(TEL_PREFIX)) {
-					String[] split = value.split(TEL_PREFIX);
-					if(pattern.matcher(split[1]).matches()) {
-						return true;
-					}
-				}
-					
-			}
-			
 			if(pattern.matcher(value).matches()) {
 				return true;
 			}
@@ -170,7 +152,7 @@ public class SingleInputValidator {
 		inputTypeToRegexMap.put(InputType.DATETIME, Pattern.compile("[1|2]{1}[0-9]{3}[-]{1}[0-9]{2}[-]{1}[0-9]{2}[T]{1}[0-9]{2}[:]{1}[0-9]{2}[:]{1}[0-9]{2}"));
 		inputTypeToRegexMap.put(InputType.GYEAR, Pattern.compile("[0-9]{4}"));
 		inputTypeToRegexMap.put(InputType.DURATION, Pattern.compile("P(?:(?:\\d+D|\\d+M(?:\\d+D)?|\\d+Y(?:\\d+M(?:\\d+D)?)?)(?:T(?:\\d+H(?:\\d+M(?:\\d+S)?)?|\\d+M(?:\\d+S)?|\\d+S))?|T(?:\\d+H(?:\\d+M(?:\\d+S)?)?|\\d+M(?:\\d+S)?|\\d+S)|\\d+W)"));
-		inputTypeToRegexMap.put(InputType.PHONENUMBER, Pattern.compile("^(?:\\+?(\\d{1,3}))?([-. (]*(\\d{3})[-. )]*)?((\\d{3})[-. ]*(\\d{2,4})(?:[-.x ]*(\\d+))?)$"));
+		inputTypeToRegexMap.put(InputType.PHONENUMBER, Pattern.compile("^(?:tel:)?(?:\\+?(\\d{1,3}))?([-. (]*(\\d{3})[-. )]*)?((\\d{3})[-. ]*(\\d{2,4})(?:[-.x ]*(\\d+))?)$"));
 	}
 	
 	//Predefined errormessage

--- a/src/main/java/se/ams/dcatprocessor/util/DcatPropertyHandler.java
+++ b/src/main/java/se/ams/dcatprocessor/util/DcatPropertyHandler.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import java.util.regex.Pattern;
 
 import se.ams.dcatprocessor.ApplicationProperties;
+import se.ams.dcatprocessor.rdf.DcatException;
 
 public class DcatPropertyHandler {
 	
@@ -93,11 +94,10 @@ public class DcatPropertyHandler {
 				typeValues.put(key, valueSplit[1].split(COMMA));
 	
 			}
-			
+	
 		} catch (IOException e) {
-			e.printStackTrace();
+			throw new DcatException("Failed to load DCAT properties: " + e.getMessage());
 		}
-		
 	}
 	
 	public String[] getPropertyKeys() {

--- a/src/test/java/se/ams/dcatprocessor/processor/DcatV301IntegrationTest.java
+++ b/src/test/java/se/ams/dcatprocessor/processor/DcatV301IntegrationTest.java
@@ -165,8 +165,8 @@ public class DcatV301IntegrationTest {
 
     @ParameterizedTest
     @CsvSource({
-        "subject,                   http://purl.org/dc/terms/,      http://eurovoc.europa.eu/100142",
-        "subject,                   http://purl.org/dc/terms/,      http://eurovoc.europa.eu/5237",
+        "subject,                   http://purl.org/dc/terms/,      https://dataportal.se/concepts/grunddata/person",
+        "subject,                   http://purl.org/dc/terms/,      https://dataportal.se/concepts/grunddata/foretag",
         "hvdCategory,               http://data.europa.eu/r5r#,     http://data.europa.eu/bna/c_a9135398",
         "hvdCategory,               http://data.europa.eu/r5r#,     http://data.europa.eu/bna/c_dd313021",
         "applicableLegislation,     http://data.europa.eu/r5r#,     http://data.europa.eu/eli/reg_impl/2023/138/oj",
@@ -210,8 +210,7 @@ public class DcatV301IntegrationTest {
 
     @ParameterizedTest
     @CsvSource({
-        "subject,                   http://purl.org/dc/terms/,      http://eurovoc.europa.eu/100142",
-        "subject,                   http://purl.org/dc/terms/,      http://eurovoc.europa.eu/1082",
+        "subject,                   http://purl.org/dc/terms/,      https://dataportal.se/concepts/grunddata/person",
         "hvdCategory,               http://data.europa.eu/r5r#,     http://data.europa.eu/bna/c_a9135398",
         "applicableLegislation,     http://data.europa.eu/r5r#,     http://data.europa.eu/eli/reg_impl/2023/138/oj",
     })
@@ -296,9 +295,8 @@ public class DcatV301IntegrationTest {
         "hvdCategory,           http://data.europa.eu/r5r#,     http://data.europa.eu/bna/c_a9135398",
         "hvdCategory,           http://data.europa.eu/r5r#,     http://data.europa.eu/bna/c_dd313021",
         "applicableLegislation, http://data.europa.eu/r5r#,     http://data.europa.eu/eli/reg_impl/2023/138/oj",
-        "spatial,               http://purl.org/dc/terms/,      https://www.geonames.org/6695072/european-union.html",
-        "subject,               http://purl.org/dc/terms/,      http://eurovoc.europa.eu/100142",
-        "subject,               http://purl.org/dc/terms/,      http://eurovoc.europa.eu/5237",
+        "spatial,               http://purl.org/dc/terms/,      http://sws.geonames.org/6695072",
+        "subject,               http://purl.org/dc/terms/,      https://dataportal.se/concepts/grunddata/foretag",
         "relation,              http://purl.org/dc/terms/,      https://www.example.se/relaterad-resurs",
         "accrualPeriodicity,    http://purl.org/dc/terms/,      http://publications.europa.eu/resource/authority/frequency/ANNUAL",
     })
@@ -409,8 +407,8 @@ public class DcatV301IntegrationTest {
     void testThatDatasetSeriesContainsSpatial() throws Exception {
         IRI series = vf.createIRI("https://www.example.se/#datasetseriesC");
         IRI spatial = vf.createIRI("https://www.example.se/#datasetseriesC/spatial");
-        Literal expectedBbox = vf.createLiteral("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
-        Literal expectedCentroid = vf.createLiteral("POINT(10.0 51.0)");
+        Literal expectedBbox = vf.createLiteral("POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))");
+        Literal expectedCentroid = vf.createLiteral("POINT (12.83 56.4)");
 
         String result = manager.createDcatFromFile(API_DEF_FILE);
 

--- a/src/test/java/se/ams/dcatprocessor/processor/ErrorReporterTest.java
+++ b/src/test/java/se/ams/dcatprocessor/processor/ErrorReporterTest.java
@@ -31,12 +31,6 @@ public class ErrorReporterTest {
     }
 
     @Test
-    void testThatBuildErrorReportContainsDocsUrlWhenErrorsExist() {
-        String report = errorReporter.buildErrorReport(Map.of("api.yaml", "Invalid format"), Map.of());
-        assertTrue(report.contains("https://docs.dataportal.se/dcat/sv/"));
-    }
-
-    @Test
     void testThatBuildErrorReportReportsExceptionsErrors() {
         String filename = "api.yaml";
         String msg = "Invalid format";
@@ -59,25 +53,5 @@ public class ErrorReporterTest {
         assertTrue(report.contains(value));
         assertTrue(report.contains(filename));
         assertTrue(report.contains(ErrorType.DUPLICATE_URI_BETWEEN_FILES.toString()));
-    }
-
-    @Test
-    void testThatBuildErrorReportReportsBothErrorTypes() {
-        String file1 = "catalog.yaml";
-        String file2 = "api.yaml";
-        String field = "About";
-        String errorMsg = "Invalid format";
-
-        ValidationError validationError = new ValidationError(ErrorType.DUPLICATE_URI_BETWEEN_FILES, new String[]{file1}, field);
-        Map<String, List<ValidationError>> validationErrors = Map.of(file1, List.of(validationError));
-        Map<String, String> exceptions = Map.of(file2, errorMsg);
-
-        String report = errorReporter.buildErrorReport(exceptions, validationErrors);
-
-        assertTrue(report.contains(file1));
-        assertTrue(report.contains(field));
-        assertTrue(report.contains(ErrorType.DUPLICATE_URI_BETWEEN_FILES.toString()));
-        assertTrue(report.contains(file2));
-        assertTrue(report.contains(errorMsg));
     }
 }

--- a/src/test/resources/apidef/json_v3/json_oas_301.json
+++ b/src/test/resources/apidef/json_v3/json_oas_301.json
@@ -5,7 +5,7 @@
     "title": "Annotation exempel api 3.0.1",
     "description": "Testfil för uppgradering 2.0 => 3.0.1. Bygger på full_example_oas.json med samtliga nya 3.0.1-fält tillagda.",
     "x-dcat": {
-      "dcat-catalog": {
+      "dcat-catalog": { 
         "about": "https://www.af.se",
         "title-sv": "Exempel på catalog för en organisation med flera api'n",
         "title-en": "Example of a catalog for an organistaion with several api's",
@@ -26,6 +26,12 @@
         "issued": "2021-04-01",
         "homepage": "www.arbetsformedlingen.se",
         "modified": "2021-04-02",
+        "location": {
+          "about": "https://www.af.se#location",
+          "bbox": "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+          "centroid": "POINT(10.0 51.0)",
+          "geometry": "POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))"
+        },
         "rights": {
           "attributionText-sv": "Detta är ett exempel på rättighetstext för Catalog",
           "attributionURL": "www.rattighetstextcatalog.se",
@@ -52,7 +58,7 @@
         "title-en": "Dataset series C",
         "description-sv": "Exempel av Datasetseries (ny primärklass i 3.0.1)",
         "description-en": "Example of Datasetseries (new primaryclass in 3.0.1)",
-        "subject": "http://eurovoc.europa.eu/100142; http://eurovoc.europa.eu/5237",
+        "subject": "https://dataportal.se/concepts/grunddata/foretag",
         "hvdCategory": "http://data.europa.eu/bna/c_a9135398; http://data.europa.eu/bna/c_dd313021",
         "modified": "2021-02-15",
         "contactPoint": {
@@ -68,11 +74,12 @@
         "keyword-en": "series; example",
         "theme": "TRAN",
         "issued": "2021-02-01",
-        "spatialUrl": "https://www.geonames.org/6695072/european-union.html",
+        "spatialUrl": "http://sws.geonames.org/6695072",
         "location": {
           "about": "https://www.example.se/#datasetseriesC/spatial",
-          "bbox": "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
-          "centroid": "POINT(10.0 51.0)"
+          "bbox": "POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))",
+          "centroid": "POINT (12.83 56.4)",
+          "geometry": "POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))"
         },
         "temporal": {
           "startDate": "2021-01-01",
@@ -108,7 +115,7 @@
         "description-sv": "Exempel beskrivning datamängd C",
         "inSeries": "https://www.example.se/#datasetseriesC",
         "version": "3.7.5",
-        "subject": "http://eurovoc.europa.eu/100142; http://eurovoc.europa.eu/5237",
+        "subject": "https://dataportal.se/concepts/grunddata/person; https://dataportal.se/concepts/grunddata/foretag",
         "applicableLegislation": "http://data.europa.eu/eli/reg_impl/2023/138/oj",
         "hvdCategory": "http://data.europa.eu/bna/c_a9135398; http://data.europa.eu/bna/c_dd313021",
         "creator": {
@@ -148,7 +155,12 @@
         "theme": "TRAN; EDUC",
         "issued": "2021-03-05",
         "modified": "2021-03-15",
-        "spatialUrl": "https://www.geonames.org/6695072/european-union.html",
+        "location": {
+          "about": "https://www.example.se/#datasetC/spatial",
+          "bbox": "POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))",
+          "centroid": "POINT (12.83 56.4)",
+          "geometry": "POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))"
+        },
         "versionNotes": "Exempel på VersionsNoteringar; Fler versionsnoteringar",
         "landingPage": "www.exempelsida.se",
         "temporalResolution": "P1Y",
@@ -213,7 +225,7 @@
             "reuserGuidelines": "www.guidelines.se"
           },
           "checksum": {
-            "value": "A23DF"
+            "value": "0A23DF"
           },
           "page": {
             "about": "https://www.example.se/#distributionC/page",
@@ -234,7 +246,7 @@
         "endpointURL": "www.datatjanstC.se",
         "endpointDescription": "www.beskrivningDatatjanstC.se",
         "format": "application/json",
-        "subject": "http://eurovoc.europa.eu/100142; http://eurovoc.europa.eu/1082",
+        "subject": "https://dataportal.se/concepts/grunddata/person",
         "applicableLegislation": "http://data.europa.eu/eli/reg_impl/2023/138/oj",
         "hvdCategory": "http://data.europa.eu/bna/c_a9135398",
         "publisher": {


### PR DESCRIPTION
## Summary

Refactoring that improves the structure of the converter classes and cleans up error handling for the parser/processor layers. Also solves some long-standing TODOs and updates the test fixtures to align with DCAT-AP-SE 3.0.1.

Fixes #59

## Changes

### refactor: clean up converter classes and manager
- Dependency injection for `Converter` classes
- `ConverterFiles`: remove unused logic
- `Converter` (base class): remove unused logic
- `Manager`: take converters from Spring context, improved error handling
- `ErrorReporter`: align with `Manager` changes

### refactor: error handling in DcatPropertyHandler and ApiDefinitionParser
- Consistent error handling with DcatException for DcatPropertyHandler and ApiDefinitionParser

### fix: solve misc TODOs
- Phone number regex now accepts the `tel:` prefix
- Remove hardcoded `vcard:hasValue`
- Add description for `dcatClass` and `checkedElsewhere` on `CardinalityValidator.validate`

### test: update test JSON file and minor adjustments
- Update test file for v3.0.1 with additional fields
- `IntegrationTest`: use valid `subject` and `spatial`
- `ErrorReporter` test updated to match class changes


## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
