### PR TITLE
fix: correct URIs for adms:status

### DIFF
--- a/src/main/resources/to_dcat_files/supportive_files/status.json
+++ b/src/main/resources/to_dcat_files/supportive_files/status.json
@@ -1,26 +1,18 @@
 {
     "Deprecated": {
-        "title" : "Avvecklad",
-        "url": "http://purl.org/adms/status/Deprecated"
+        "title": "Avvecklad",
+        "url": "http://publications.europa.eu/resource/authority/distribution-status/DEPRECATED"
     },
     "Completed": {
-        "title" : "Färdig",
-        "url": "http://purl.org/adms/status/Completed"
+        "title": "Färdig",
+        "url": "http://publications.europa.eu/resource/authority/distribution-status/COMPLETED"
     },
     "Withdrawn": {
-        "title" : "Tillbakadragen",
-        "url": "http://purl.org/adms/status/Withdrawn"
+        "title": "Tillbakadragen",
+        "url": "http://publications.europa.eu/resource/authority/distribution-status/WITHDRAWN"
     },
     "UnderDevelopment": {
-        "title" : "Under utveckling",
-        "url": "http://purl.org/adms/status/UnderDevelopment"
+        "title": "Under utveckling",
+        "url": "http://publications.europa.eu/resource/authority/distribution-status/DEVELOP"
     }
 }
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## New URIs for adms:status

Replaces the adms:status URIs from the old: purl.org/adms/status/*
To the new (from DCAT-AP 3.0): publications.europa.eu/resource/authority/distribution-status/*

Fixes #72

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
