### PR TITLE
fix: datatype for byteSize

### DIFF
--- a/src/main/java/se/ams/dcatprocessor/rdf/RDFWorker.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/RDFWorker.java
@@ -6,7 +6,6 @@ package se.ams.dcatprocessor.rdf;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.time.Period;
 import java.time.temporal.TemporalAmount;
@@ -757,31 +756,29 @@ public class RDFWorker {
 	}
 
 	/**
-	 * Converts a string to a BigDecimal object if possible. Otherwise returns null
+	 * Returns the numeric datatype matching the InputType
 	 * @param key - Used to get the allowable InputType(s)
-	 * @param value - The value to be converted
-	 * @return - The resulting BigDecimal object or null 
+	 * @return - The matching datatype
 	 */
-	private BigDecimal getBigDecimal(String key, String value) {
-	    if (Util.isNullOrEmpty(key) || Util.isNullOrEmpty(value)) {
-	        return null; 
+	private IRI getNumericDatatype(String key) {
+	    if (Util.isNullOrEmpty(key)) {
+	        return null;
 	    }
-	    
+		
 	    List<InputType> inputTypes = SingleInputValidator.getInstance().getInputTypes(key);
-	    
-	    if(inputTypes.contains(InputType.INTEGER) || inputTypes.contains(InputType.DECIMAL)) {
-	    	try {
-			    return new BigDecimal(value);
-			    /**
-			     * No need to logg error here.
-			     * Its has been already checked in SingleInputValidator
-			     */
-			} catch (NumberFormatException e) {
-				return null;
-			}
+
+	    IRI datatype = null;
+	    if (inputTypes.contains(InputType.NONNEGATIVEINTEGER)) {
+	        datatype = XSD.NON_NEGATIVE_INTEGER;
+	    } else if (inputTypes.contains(InputType.INTEGER)) {
+	        datatype = XSD.INTEGER;
+	    } else if (inputTypes.contains(InputType.DECIMAL)) {
+	        datatype = XSD.DECIMAL;
+	    } else {
+	        return null;
 	    }
 
-	    return null;
+	    return datatype;
 	}
 
 	/**
@@ -863,9 +860,9 @@ public class RDFWorker {
 					/**
 					 * First check if its a numeric value...otherwise it might be interpreted as date value further down
 					 */
-					BigDecimal bigDecimal = getBigDecimal(key, value);
-					if(Util.isNotNullOrEmpty(bigDecimal)) {
-						model.add(sectionIRI, iri, valueFactory.createLiteral(bigDecimal));
+					IRI numericDatatype = getNumericDatatype(key);
+					if(numericDatatype != null) {
+						model.add(sectionIRI, iri, valueFactory.createLiteral(value, numericDatatype));
 					} else {
 						TemporalAmount temporalAmount = getTemporalAmount(key, value);
 						if (Util.isNotNullOrEmpty(temporalAmount)) {
@@ -882,15 +879,11 @@ public class RDFWorker {
 							} else {					//All other values....for now
 								model.add(sectionIRI, iri, valueFactory.createLiteral(value));
 							}
-								
 						}
-
 					}
 				}
-
 			}
 		}
-
 	}
 	
 	// Regexp pattern used for date-format checking

--- a/src/main/java/se/ams/dcatprocessor/rdf/validate/InputType.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/validate/InputType.java
@@ -16,6 +16,7 @@ public enum InputType {
 	DATETIME("xsd:dateTime"),
 	GYEAR("xsd:gYear"),
 	INTEGER("xsd:integer"),
+	NONNEGATIVEINTEGER("xsd:nonNegativeInteger"),
 	DECIMAL("xsd:decimal"),
 	DURATION("xsd:duration"),
 	ANYURI("xsd:anyURI"),

--- a/src/main/java/se/ams/dcatprocessor/rdf/validate/SingleInputValidator.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/validate/SingleInputValidator.java
@@ -165,6 +165,7 @@ public class SingleInputValidator {
 		inputTypeToRegexMap = new HashMap<InputType, Pattern>();
 		inputTypeToRegexMap.put(InputType.STRING, Pattern.compile(".*"));
 		inputTypeToRegexMap.put(InputType.INTEGER, Pattern.compile("^\\d{1,10}$"));
+		inputTypeToRegexMap.put(InputType.NONNEGATIVEINTEGER, Pattern.compile("^\\d+$"));
 		inputTypeToRegexMap.put(InputType.DECIMAL, Pattern.compile("^[0-9]+([\\.][0-9]+)?$"));
 		inputTypeToRegexMap.put(InputType.DATE, Pattern.compile("[1|2]{1}[0-9]{3}[-]{1}[0-9]{2}[-]{1}[0-9]{2}"));
 		inputTypeToRegexMap.put(InputType.DATETIME, Pattern.compile("[1|2]{1}[0-9]{3}[-]{1}[0-9]{2}[-]{1}[0-9]{2}[T]{1}[0-9]{2}[:]{1}[0-9]{2}[:]{1}[0-9]{2}"));

--- a/src/main/resources/dcat_specification.properties
+++ b/src/main/resources/dcat_specification.properties
@@ -23,6 +23,7 @@
 # xsd:duration
 # xsd:decimal
 # xsd:integer
+# xsd:nonNegativeInteger
 # phoneNumber
 # class - Complex type
 ##
@@ -121,7 +122,7 @@ distribution.dcterms\:format=0..n|xsd:string
 distribution.dcat\:accessService=0..n|class
 distribution.dcat\:temporalResolution=0..1|xsd:duration
 distribution.dcat\:spatialResolutionInMeters=0..1|xsd:decimal
-distribution.dcat\:byteSize=0..1|xsd:integer
+distribution.dcat\:byteSize=0..1|xsd:nonNegativeInteger
 distribution.dcterms\:language=0..n|xsd:anyURI
 distribution.dcterms\:issued=0..1|xsd:date,xsd:dateTime,xsd:gYear
 distribution.dcterms\:modified=0..1|xsd:date,xsd:dateTime,xsd:gYear

--- a/src/test/java/se/ams/dcatprocessor/processor/IntegrationTest.java
+++ b/src/test/java/se/ams/dcatprocessor/processor/IntegrationTest.java
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2022 Agency for Digital Government
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.ams.dcatprocessor.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.DCAT;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import se.ams.dcatprocessor.converter.Converter;
+import se.ams.dcatprocessor.testutil.TestHelper;
+
+@SpringBootTest 
+public class IntegrationTest {
+
+    @Autowired
+    private ObjectProvider<Manager> managerProvider;
+
+    private Manager manager;
+    private final ValueFactory vf = SimpleValueFactory.getInstance();
+    private final String API_DEF_FILE = "src/test/resources/apidef/json_v3/json_oas_301.json";
+    
+    @BeforeEach
+	void setup() throws Exception {
+        TestHelper.resetSingeltons();
+        Converter.errors.clear();
+		manager = managerProvider.getObject();
+	}
+
+    @Test
+    void testThatByteSizeIsNonNegativeInteger() throws RDFParseException, UnsupportedRDFormatException, IOException{
+        IRI distribution = vf.createIRI("https://www.example.se/#distributionC");
+
+        String result = manager.createDcatFromFile(API_DEF_FILE);
+        Model model = Rio.parse(new StringReader(result), "", RDFFormat.RDFXML);
+
+        Literal actual = Models.objectLiteral(
+                model.filter(distribution, DCAT.BYTE_SIZE, null))
+            .orElseThrow(() -> new AssertionError("No byteSize on " + distribution));
+
+        assertEquals("3000", actual.getLabel(), "byteSize value");
+        assertEquals(XSD.NON_NEGATIVE_INTEGER, actual.getDatatype(), "byteSize datatype");
+    }
+}

--- a/src/test/java/se/ams/dcatprocessor/rdf/SingleInputValidatorTest.java
+++ b/src/test/java/se/ams/dcatprocessor/rdf/SingleInputValidatorTest.java
@@ -129,8 +129,8 @@ class SingleInputValidatorTest {
 		"dcat:temporalResolution,			P5Y2M10D",				// valid duration
 		"dcat:spatialResolutionInMeters,	1.093",					// valid decimal
 		"dcat:spatialResolutionInMeters,	50.0",					// valid decimal
-		"dcat:byteSize,						1093",					// valid integer
-		"dcat:byteSize,						1",						// valid integer
+		"dcat:byteSize,						1093",					// valid nonNegativeInteger
+		"dcat:byteSize,						1",						// valid nonNegativeInteger
 		"dcterms:issued,					2001-10-26",			// valid Date
 		"dcterms:issued,					2002-05-30T09:30:10",	// valid Datetime
 		"dcterms:issued,					1982",					// valid year
@@ -155,7 +155,9 @@ class SingleInputValidatorTest {
 		"foaf:homepage, 					://ams.se", 			// URI wrong format
 		"dcat:temporalResolution, 			5Y2M10D", 				// Duration wrong format
 		"dcat:spatialResolutionInMeters,	',01'",					// invalid decimal
-		"dcat:byteSize,						12345Y",				// invalid integer
+		"dcat:byteSize,						12345Y",				// invalid nonNegativeInteger
+		"dcat:byteSize,						-100",					// invalid nonNegativeInteger
+		"dcat:byteSize,						64.5",					// invalid nonNegativeInteger
 		"vcard:hasValue,			        0771-71u 7178",			// invalid phonenumber format
 		"vcard:hasValue,			        -0711 7178",			// invalid phonenumber format
 		"vcard:hasValue,			        ?46104794000",			// invalid phonenumber format


### PR DESCRIPTION
## Summary

byteSize is currently being mapped as a integer, this is not inline with DCAT-AP-SE specification and validation at Dataportalen fails with the error:  `dcat:byteSize Fel datatyp`

This PR changes the mapping of byteSize to the correct datatype which is nonNegativeInteger. 

## Changes

- byteSize mapped to nonNegativeInteger, changes i dcat_specification, RDFWorker and SingleInputValidator
- add regex for validation of nonNegativeInteger
- integrationTest to confirm change
- update unittests for byteSize validation

Fixes #71

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
