### PR TITLE
Fix/70 mapping of spatial and location

### DIFF
--- a/src/main/java/se/ams/dcatprocessor/rdf/RDFWorker.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/RDFWorker.java
@@ -6,7 +6,6 @@ package se.ams.dcatprocessor.rdf;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.time.Period;
 import java.time.temporal.TemporalAmount;
@@ -757,31 +756,29 @@ public class RDFWorker {
 	}
 
 	/**
-	 * Converts a string to a BigDecimal object if possible. Otherwise returns null
+	 * Returns the numeric datatype matching the InputType
 	 * @param key - Used to get the allowable InputType(s)
-	 * @param value - The value to be converted
-	 * @return - The resulting BigDecimal object or null 
+	 * @return - The matching datatype
 	 */
-	private BigDecimal getBigDecimal(String key, String value) {
-	    if (Util.isNullOrEmpty(key) || Util.isNullOrEmpty(value)) {
-	        return null; 
+	private IRI getNumericDatatype(String key) {
+	    if (Util.isNullOrEmpty(key)) {
+	        return null;
 	    }
-	    
+		
 	    List<InputType> inputTypes = SingleInputValidator.getInstance().getInputTypes(key);
-	    
-	    if(inputTypes.contains(InputType.INTEGER) || inputTypes.contains(InputType.DECIMAL)) {
-	    	try {
-			    return new BigDecimal(value);
-			    /**
-			     * No need to logg error here.
-			     * Its has been already checked in SingleInputValidator
-			     */
-			} catch (NumberFormatException e) {
-				return null;
-			}
+
+	    IRI datatype = null;
+	    if (inputTypes.contains(InputType.NONNEGATIVEINTEGER)) {
+	        datatype = XSD.NON_NEGATIVE_INTEGER;
+	    } else if (inputTypes.contains(InputType.INTEGER)) {
+	        datatype = XSD.INTEGER;
+	    } else if (inputTypes.contains(InputType.DECIMAL)) {
+	        datatype = XSD.DECIMAL;
+	    } else {
+	        return null;
 	    }
 
-	    return null;
+	    return datatype;
 	}
 
 	/**
@@ -863,9 +860,9 @@ public class RDFWorker {
 					/**
 					 * First check if its a numeric value...otherwise it might be interpreted as date value further down
 					 */
-					BigDecimal bigDecimal = getBigDecimal(key, value);
-					if(Util.isNotNullOrEmpty(bigDecimal)) {
-						model.add(sectionIRI, iri, valueFactory.createLiteral(bigDecimal));
+					IRI numericDatatype = getNumericDatatype(key);
+					if(numericDatatype != null) {
+						model.add(sectionIRI, iri, valueFactory.createLiteral(value, numericDatatype));
 					} else {
 						TemporalAmount temporalAmount = getTemporalAmount(key, value);
 						if (Util.isNotNullOrEmpty(temporalAmount)) {
@@ -882,15 +879,11 @@ public class RDFWorker {
 							} else {					//All other values....for now
 								model.add(sectionIRI, iri, valueFactory.createLiteral(value));
 							}
-								
 						}
-
 					}
 				}
-
 			}
 		}
-
 	}
 	
 	// Regexp pattern used for date-format checking

--- a/src/main/java/se/ams/dcatprocessor/rdf/RDFWorker.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/RDFWorker.java
@@ -27,6 +27,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.DCAT;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.model.vocabulary.LOCN;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.ORG;
@@ -692,8 +693,10 @@ public class RDFWorker {
 				for (String value : values) {
 					
 					SingleInputValidator.getInstance().validateData(key, value);
-				
-					if (Util.isURI(value) ) { // Check if its an URI and create a resource
+					
+					if (isWKTLiteral(key)) {
+					    model.add(resource, iri, valueFactory.createLiteral(value, GEO.WKT_LITERAL));
+					} else if (Util.isURI(value)) { // Check if its an URI and create a resource
 						model.add(resource, iri, valueFactory.createIRI(value));
 					} else if (isLanguageValue(value)) { // Check if it's a language specific string, Ex en:Some text in english
 						String[] split = value.split(SUN);
@@ -750,6 +753,11 @@ public class RDFWorker {
 	private boolean isPhoneValue(String key) {
 		String vcardHasValue = VCARD4.PREFIX + ":" + VCARD4.HAS_VALUE.getLocalName();
 		return key.equals(vcardHasValue);
+	}
+
+	private boolean isWKTLiteral(String key) {
+		List<InputType> inputTypes = SingleInputValidator.getInstance().getInputTypes(key);
+		return inputTypes.contains(InputType.WKTLITERAL);
 	}
 
 	/**

--- a/src/main/java/se/ams/dcatprocessor/rdf/VocabularyStringToIRI.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/VocabularyStringToIRI.java
@@ -149,7 +149,7 @@ public class VocabularyStringToIRI {
 	
 	private static final HashMap<String, IRI> LOCATION = new HashMap<>();
 	static {
-		LOCATION.put("locn:geometry", LOCN.GEOMETRY);
+		LOCATION.put("locn:geometry", LOCN.GEOMETRY_PROP);
 	}
 	
 	private static final HashMap<String, IRI> SCHEMA_MAP = new HashMap<>();

--- a/src/main/java/se/ams/dcatprocessor/rdf/validate/InputType.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/validate/InputType.java
@@ -16,6 +16,7 @@ public enum InputType {
 	DATETIME("xsd:dateTime"),
 	GYEAR("xsd:gYear"),
 	INTEGER("xsd:integer"),
+	NONNEGATIVEINTEGER("xsd:nonNegativeInteger"),
 	DECIMAL("xsd:decimal"),
 	DURATION("xsd:duration"),
 	ANYURI("xsd:anyURI"),

--- a/src/main/java/se/ams/dcatprocessor/rdf/validate/InputType.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/validate/InputType.java
@@ -20,6 +20,7 @@ public enum InputType {
 	DECIMAL("xsd:decimal"),
 	DURATION("xsd:duration"),
 	ANYURI("xsd:anyURI"),
+	WKTLITERAL("geo:wktLiteral"),
 	CLASS("class"),
 	PHONENUMBER("phoneNumber");	//For VCARD phonenumber
 	

--- a/src/main/java/se/ams/dcatprocessor/rdf/validate/SingleInputValidator.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/validate/SingleInputValidator.java
@@ -165,6 +165,7 @@ public class SingleInputValidator {
 		inputTypeToRegexMap = new HashMap<InputType, Pattern>();
 		inputTypeToRegexMap.put(InputType.STRING, Pattern.compile(".*"));
 		inputTypeToRegexMap.put(InputType.INTEGER, Pattern.compile("^\\d{1,10}$"));
+		inputTypeToRegexMap.put(InputType.NONNEGATIVEINTEGER, Pattern.compile("^\\d+$"));
 		inputTypeToRegexMap.put(InputType.DECIMAL, Pattern.compile("^[0-9]+([\\.][0-9]+)?$"));
 		inputTypeToRegexMap.put(InputType.DATE, Pattern.compile("[1|2]{1}[0-9]{3}[-]{1}[0-9]{2}[-]{1}[0-9]{2}"));
 		inputTypeToRegexMap.put(InputType.DATETIME, Pattern.compile("[1|2]{1}[0-9]{3}[-]{1}[0-9]{2}[-]{1}[0-9]{2}[T]{1}[0-9]{2}[:]{1}[0-9]{2}[:]{1}[0-9]{2}"));

--- a/src/main/java/se/ams/dcatprocessor/rdf/validate/SingleInputValidator.java
+++ b/src/main/java/se/ams/dcatprocessor/rdf/validate/SingleInputValidator.java
@@ -154,6 +154,7 @@ public class SingleInputValidator {
 		inputTypeToRegexMap.put(InputType.GYEAR, Pattern.compile("[0-9]{4}"));
 		inputTypeToRegexMap.put(InputType.DURATION, Pattern.compile("P(?:(?:\\d+D|\\d+M(?:\\d+D)?|\\d+Y(?:\\d+M(?:\\d+D)?)?)(?:T(?:\\d+H(?:\\d+M(?:\\d+S)?)?|\\d+M(?:\\d+S)?|\\d+S))?|T(?:\\d+H(?:\\d+M(?:\\d+S)?)?|\\d+M(?:\\d+S)?|\\d+S)|\\d+W)"));
 		inputTypeToRegexMap.put(InputType.PHONENUMBER, Pattern.compile("^(?:tel:)?(?:\\+?(\\d{1,3}))?([-. (]*(\\d{3})[-. )]*)?((\\d{3})[-. ]*(\\d{2,4})(?:[-.x ]*(\\d+))?)$"));
+		inputTypeToRegexMap.put(InputType.WKTLITERAL, Pattern.compile("^(?:<[^>\\s]+>\\s++)?(?i:POINT|LINESTRING|POLYGON|MULTIPOINT|MULTILINESTRING|MULTIPOLYGON|GEOMETRYCOLLECTION)(?:\\s++(?:Z|M|ZM))?\\s*+\\(.*\\)$"));
 	}
 	
 	//Predefined errormessage

--- a/src/main/resources/dcat_specification.properties
+++ b/src/main/resources/dcat_specification.properties
@@ -23,6 +23,7 @@
 # xsd:duration
 # xsd:decimal
 # xsd:integer
+# xsd:nonNegativeInteger
 # phoneNumber
 # class - Complex type
 ##
@@ -121,7 +122,7 @@ distribution.dcterms\:format=0..n|xsd:string
 distribution.dcat\:accessService=0..n|class
 distribution.dcat\:temporalResolution=0..1|xsd:duration
 distribution.dcat\:spatialResolutionInMeters=0..1|xsd:decimal
-distribution.dcat\:byteSize=0..1|xsd:integer
+distribution.dcat\:byteSize=0..1|xsd:nonNegativeInteger
 distribution.dcterms\:language=0..n|xsd:anyURI
 distribution.dcterms\:issued=0..1|xsd:date,xsd:dateTime,xsd:gYear
 distribution.dcterms\:modified=0..1|xsd:date,xsd:dateTime,xsd:gYear

--- a/src/main/resources/dcat_specification.properties
+++ b/src/main/resources/dcat_specification.properties
@@ -24,6 +24,7 @@
 # xsd:decimal
 # xsd:integer
 # xsd:nonNegativeInteger
+# geo:wktLiteral
 # phoneNumber
 # class - Complex type
 ##
@@ -204,10 +205,10 @@ licensedocument.dcterms\:description=0..n|xsd:string
 standard.dcterms\:title=0..n|xsd:string
 standard.dcterms\:description=0..n|xsd:string
 
-#Location - Geografiskt område. Oklart format så vi tillåter allt
-location.dcat\:centroid=0..1|xsd:string
-location.dcat\:bbox=0..1|xsd:string
-location.locn\:geometry=0..1|xsd:string
+#Location - Geografiskt område
+location.dcat\:centroid=0..1|geo:wktLiteral
+location.dcat\:bbox=0..1|geo:wktLiteral
+location.locn\:geometry=0..1|geo:wktLiteral
 
 #PeriodOfTime - Tidsperiod
 periodoftime.dcat\:startDate=0..1|xsd:date,xsd:dateTime,xsd:gYear

--- a/src/test/java/se/ams/dcatprocessor/processor/DcatV301IntegrationTest.java
+++ b/src/test/java/se/ams/dcatprocessor/processor/DcatV301IntegrationTest.java
@@ -6,6 +6,7 @@ package se.ams.dcatprocessor.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
@@ -17,9 +18,11 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.DCAT;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.LOCN;
 import org.eclipse.rdf4j.model.vocabulary.ORG;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -406,17 +409,21 @@ public class DcatV301IntegrationTest {
     @Test
     void testThatDatasetSeriesContainsSpatial() throws Exception {
         IRI series = vf.createIRI("https://www.example.se/#datasetseriesC");
-        IRI spatial = vf.createIRI("https://www.example.se/#datasetseriesC/spatial");
-        Literal expectedBbox = vf.createLiteral("POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))");
-        Literal expectedCentroid = vf.createLiteral("POINT (12.83 56.4)");
 
         String result = manager.createDcatFromFile(API_DEF_FILE);
-
-        assertTrue(result.contains("RDF"), result);
         Model model = Rio.parse(new StringReader(result), "", RDFFormat.RDFXML);
-        assertTrue(model.contains(series, DCTERMS.SPATIAL, spatial),"DatasetSeries missing nested dcterms:spatial (geographical area)");
-        assertTrue(model.contains(spatial, DCAT.BBOX, expectedBbox),"Location resource missing dcat:bbox, or wrong value");
-        assertTrue(model.contains(spatial, DCAT.CENTROID, expectedCentroid),"Location resource missing dcat:centroid, or wrong value");
+
+        Resource location = null;
+        for (Resource candidate : Models.objectResources(model.filter(series, DCTERMS.SPATIAL, null))) {
+            if (model.contains(candidate, RDF.TYPE, DCTERMS.LOCATION)) {
+                location = candidate;
+            }
+        }
+        
+        assertNotNull(location, "DatasetSeries has no dcterms:spatial pointing at a Location node");
+        assertTrue(model.contains(location, DCAT.CENTROID, null), "Location node missing dcat:centroid");
+        assertTrue(model.contains(location, DCAT.BBOX, null), "Location node missing dcat:bbox");
+        assertTrue(model.contains(location, LOCN.GEOMETRY_PROP, null), "Location node missing locn:geometry");
     }
 
     // Publisher is set from the Catalog's publisher.

--- a/src/test/java/se/ams/dcatprocessor/processor/IntegrationTest.java
+++ b/src/test/java/se/ams/dcatprocessor/processor/IntegrationTest.java
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2022 Agency for Digital Government
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.ams.dcatprocessor.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.DCAT;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import se.ams.dcatprocessor.converter.Converter;
+import se.ams.dcatprocessor.testutil.TestHelper;
+
+@SpringBootTest 
+public class IntegrationTest {
+
+    @Autowired
+    private ObjectProvider<Manager> managerProvider;
+
+    private Manager manager;
+    private final ValueFactory vf = SimpleValueFactory.getInstance();
+    private final String API_DEF_FILE = "src/test/resources/apidef/json_v3/json_oas_301.json";
+    
+    @BeforeEach
+	void setup() throws Exception {
+        TestHelper.resetSingeltons();
+        Converter.errors.clear();
+		manager = managerProvider.getObject();
+	}
+
+    @Test
+    void testThatByteSizeIsNonNegativeInteger() throws RDFParseException, UnsupportedRDFormatException, IOException{
+        IRI distribution = vf.createIRI("https://www.example.se/#distributionC");
+
+        String result = manager.createDcatFromFile(API_DEF_FILE);
+        Model model = Rio.parse(new StringReader(result), "", RDFFormat.RDFXML);
+
+        Literal actual = Models.objectLiteral(
+                model.filter(distribution, DCAT.BYTE_SIZE, null))
+            .orElseThrow(() -> new AssertionError("No byteSize on " + distribution));
+
+        assertEquals("3000", actual.getLabel(), "byteSize value");
+        assertEquals(XSD.NON_NEGATIVE_INTEGER, actual.getDatatype(), "byteSize datatype");
+    }
+}

--- a/src/test/java/se/ams/dcatprocessor/processor/IntegrationTest.java
+++ b/src/test/java/se/ams/dcatprocessor/processor/IntegrationTest.java
@@ -16,6 +16,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.DCAT;
+import org.eclipse.rdf4j.model.vocabulary.GEO;
+import org.eclipse.rdf4j.model.vocabulary.LOCN;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParseException;
@@ -60,5 +62,41 @@ public class IntegrationTest {
 
         assertEquals("3000", actual.getLabel(), "byteSize value");
         assertEquals(XSD.NON_NEGATIVE_INTEGER, actual.getDatatype(), "byteSize datatype");
+    }
+
+    @Test
+    void testThatCentroidIsWktLiteral() throws RDFParseException, UnsupportedRDFormatException, IOException {
+        String result = manager.createDcatFromFile(API_DEF_FILE);
+        Model model = Rio.parse(new StringReader(result), "", RDFFormat.RDFXML);
+
+        Literal centroid = Models.objectLiteral(model.filter(null, DCAT.CENTROID, null))
+                .orElseThrow(() -> new AssertionError("No dcat:centroid in generated RDF"));
+
+        assertEquals("POINT(10.0 51.0)", centroid.getLabel(), "Centroid value");
+        assertEquals(GEO.WKT_LITERAL, centroid.getDatatype(), "Centroid datatype");
+    }
+
+    @Test
+    void testThatBboxIsWktLiteral() throws RDFParseException, UnsupportedRDFormatException, IOException {
+        String result = manager.createDcatFromFile(API_DEF_FILE);
+        Model model = Rio.parse(new StringReader(result), "", RDFFormat.RDFXML);
+
+        Literal bbox = Models.objectLiteral(model.filter(null, DCAT.BBOX, null))
+                .orElseThrow(() -> new AssertionError("No dcat:bbox in generated RDF"));
+
+        assertEquals("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))", bbox.getLabel(), "bbox value");
+        assertEquals(GEO.WKT_LITERAL, bbox.getDatatype(), "bbox datatype");
+    }
+
+    @Test
+    void testThatGeometryIsWktLiteral() throws RDFParseException, UnsupportedRDFormatException, IOException {
+        String result = manager.createDcatFromFile(API_DEF_FILE);
+        Model model = Rio.parse(new StringReader(result), "", RDFFormat.RDFXML);
+
+        Literal geometry = Models.objectLiteral(model.filter(null, LOCN.GEOMETRY_PROP, null))
+                .orElseThrow(() -> new AssertionError("No locn:geometry in generated RDF"));
+
+        assertEquals("LINESTRING(10.0 51.0, 11.0 52.0, 12.0 53.0)", geometry.getLabel(), "geometry value");
+        assertEquals(GEO.WKT_LITERAL, geometry.getDatatype(), "geometry datatype");
     }
 }

--- a/src/test/java/se/ams/dcatprocessor/rdf/RDFWorkerTest.java
+++ b/src/test/java/se/ams/dcatprocessor/rdf/RDFWorkerTest.java
@@ -470,10 +470,7 @@ class RDFWorkerTest {
 				List.of("Erkännandetext 1", "http://www.attributionURL1.com", "Meddelande om upphovsrätt 1", "2021", "http://www.jurisdictionURL1.com", "http://www.reuserGuidelinesURL1.com"));
 				
 		//Add geographic area
-		DataClass spatial = new DataClass();
-		spatial.dcData.put("dcat:centroid", "en¤The geographic center of a resource 1");
-		spatial.dcData.put("dcat:bbox", "sv¤The geographic bounding box of a resource 1");
-		spatial.dcData.put("locn:geometry", "Any resource with the corresponding geometry 1");
+		DataClass spatial = createSpatial();
 		catalog.spatial.add(spatial);
 
 		DataClass agent = new DataClass();
@@ -537,13 +534,8 @@ class RDFWorkerTest {
 		temporal.dcData.put("dcat:endDate", "2022-02-26");
 		dataSet2.temporals.add(temporal);
 
-		//TODO: Add dcat:centroid, dcat:bbox and locn:geometry on the correct format. Find it!! 
 		//Add geographic area
-		DataClass spatial = new DataClass();
-		spatial = new DataClass();
-		spatial.dcData.put("dcat:centroid", "en¤The geographic center of a resource 2");
-		spatial.dcData.put("dcat:bbox", "sv¤The geographic bounding box of a resource 2");
-		spatial.dcData.put("locn:geometry", "Any resource with the corresponding geometry 2");
+		DataClass spatial = createSpatial();
 		dataSet2.spatial.add(spatial);
 
 		fileStorage.dcat_dataset.add(dataSet2);
@@ -873,6 +865,14 @@ class RDFWorkerTest {
 		dataService1.agents.add(agent3);
 		
 		return List.of(fileStorage);
+	}
+
+	private DataClass createSpatial() {
+		DataClass spatial = new DataClass();
+		spatial.dcData.put("dcat:centroid", "POINT(18.07 59.33)");
+		spatial.dcData.put("dcat:bbox", "POLYGON((10.9 55.3, 24.2 55.3, 24.2 69.1, 10.9 69.1, 10.9 55.3))");
+		spatial.dcData.put("locn:geometry", "LINESTRING(18.07 59.33, 17.64 59.86, 16.19 58.59)");
+		return spatial;
 	}
 	
 	private DataClass createOtherAgent(List<String> key, List<String> value) {

--- a/src/test/java/se/ams/dcatprocessor/rdf/SingleInputValidatorTest.java
+++ b/src/test/java/se/ams/dcatprocessor/rdf/SingleInputValidatorTest.java
@@ -129,8 +129,8 @@ class SingleInputValidatorTest {
 		"dcat:temporalResolution,			P5Y2M10D",				// valid duration
 		"dcat:spatialResolutionInMeters,	1.093",					// valid decimal
 		"dcat:spatialResolutionInMeters,	50.0",					// valid decimal
-		"dcat:byteSize,						1093",					// valid integer
-		"dcat:byteSize,						1",						// valid integer
+		"dcat:byteSize,						1093",					// valid nonNegativeInteger
+		"dcat:byteSize,						1",						// valid nonNegativeInteger
 		"dcterms:issued,					2001-10-26",			// valid Date
 		"dcterms:issued,					2002-05-30T09:30:10",	// valid Datetime
 		"dcterms:issued,					1982",					// valid year
@@ -155,7 +155,9 @@ class SingleInputValidatorTest {
 		"foaf:homepage, 					://ams.se", 			// URI wrong format
 		"dcat:temporalResolution, 			5Y2M10D", 				// Duration wrong format
 		"dcat:spatialResolutionInMeters,	',01'",					// invalid decimal
-		"dcat:byteSize,						12345Y",				// invalid integer
+		"dcat:byteSize,						12345Y",				// invalid nonNegativeInteger
+		"dcat:byteSize,						-100",					// invalid nonNegativeInteger
+		"dcat:byteSize,						64.5",					// invalid nonNegativeInteger
 		"vcard:hasValue,			        0771-71u 7178",			// invalid phonenumber format
 		"vcard:hasValue,			        -0711 7178",			// invalid phonenumber format
 		"vcard:hasValue,			        ?46104794000",			// invalid phonenumber format

--- a/src/test/java/se/ams/dcatprocessor/rdf/SingleInputValidatorTest.java
+++ b/src/test/java/se/ams/dcatprocessor/rdf/SingleInputValidatorTest.java
@@ -137,7 +137,9 @@ class SingleInputValidatorTest {
 		"vcard:hasValue,					0771-717 717",			// valid phonenumber format
 		"vcard:hasValue,					+46104794000",			// valid phonenumber format
 		"vcard:hasValue,					tel:+46104794000",		// valid phonenumber format
-
+		"locn:geometry,     				'LINESTRING(10.0 51.0, 11.0 52.0, 12.0 53.0)'",	// valid LINESTRING
+		"dcat:bbox,         				'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'",         	// valid POLYGON
+		"dcat:centroid,     				POINT(10.0 51.0)",                      		// valid POINT
 	})
 	void testThatValidValuesPassValidation(String key, String value) throws Exception {	
 		SingleInputValidator instance = SingleInputValidator.getInstance();
@@ -164,6 +166,9 @@ class SingleInputValidatorTest {
 		"dcterms:issued,			        2001-0-26",				// invalid Date
 		"dcterms:issued,			        2002-05-30T09:30",		// invalid Datetime
 		"dcterms:issued,			        192",					// invalid Year
+		"locn:geometry,     				LINESTRING 10.0 51.0",	// missing parentheses
+		"dcat:bbox,         				Sverige",         		// invalid geometry
+		"dcat:centroid,     				POINTX(10.0 51.0)",     // unknown geometry type
 	})
 	void testThatInvalidValuesFailValidation(String key, String value) throws Exception {
 		ValidationErrorStorage validationErrorStorage = ValidationErrorStorage.getInstance();	

--- a/src/test/resources/apidef/json_v3/json_oas_301.json
+++ b/src/test/resources/apidef/json_v3/json_oas_301.json
@@ -30,7 +30,7 @@
           "about": "https://www.af.se#location",
           "bbox": "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
           "centroid": "POINT(10.0 51.0)",
-          "geometry": "POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))"
+          "geometry": "LINESTRING(10.0 51.0, 11.0 52.0, 12.0 53.0)"
         },
         "rights": {
           "attributionText-sv": "Detta är ett exempel på rättighetstext för Catalog",
@@ -76,10 +76,9 @@
         "issued": "2021-02-01",
         "spatialUrl": "http://sws.geonames.org/6695072",
         "location": {
-          "about": "https://www.example.se/#datasetseriesC/spatial",
-          "bbox": "POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))",
-          "centroid": "POINT (12.83 56.4)",
-          "geometry": "POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))"
+          "geometry": "LINESTRING(10.0 51.0, 11.0 52.0, 12.0 53.0)",
+          "bbox": "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+          "centroid": "POINT(10.0 51.0)"
         },
         "temporal": {
           "startDate": "2021-01-01",
@@ -159,7 +158,7 @@
           "about": "https://www.example.se/#datasetC/spatial",
           "bbox": "POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))",
           "centroid": "POINT (12.83 56.4)",
-          "geometry": "POLYGON ((12.42 56.3, 13.24 56.3, 13.24 56.5, 12.42 56.5, 12.42 56.3))"
+          "geometry": "LINESTRING(10.0 51.0, 11.0 52.0, 12.0 53.0)"
         },
         "versionNotes": "Exempel på VersionsNoteringar; Fler versionsnoteringar",
         "landingPage": "www.exempelsida.se",

--- a/src/test/resources/dcat_specification_test_1.properties
+++ b/src/test/resources/dcat_specification_test_1.properties
@@ -23,3 +23,8 @@ distribution.dcat\:temporalResolution=0..1|xsd:duration
 distribution.dcat\:spatialResolutionInMeters=0..1|xsd:decimal
 distribution.dcat\:byteSize=0..1|xsd:integer
 voice.vcard\:hasValue=1|phoneNumber
+
+#Location
+location.dcat\:centroid=0..1|geo:wktLiteral
+location.dcat\:bbox=0..1|geo:wktLiteral
+location.locn\:geometry=0..1|geo:wktLiteral


### PR DESCRIPTION
## Summary

The properties: **geometry**, **bbox** and **centroid** in the Location block were all mapped as datatype string. DCAT-AP-SE specification has them as geo:wktLiteral. This PR changes the datatype for these properties to match the specification. 

This includes creating a new datatype: WKTLITERAL and regex validation for the datatype. Minor changes in RDFWorker have also been implemented so that processing of the new datatype is supported.

### Changes
- geometry, bbox and centroid mapped as geo:wktLiteral.
- Added InputType WKTLITERAL and regex for validation.
- RDFWorker handles WKTLiteral in addDataToNode.
- Corrected locn:geometry HashMap value in VocabularyStringToIRI.

### Test
- IntegrationsTest for geometry, bbox and centroid.
- Updated old tests that were dependent on wrong datatype.
- Unittest for new regex in SingleInputValidator.

### Note
This branch and PR builds on `fix/71-byteSize-datatype` which should be merged before this one.


Fixes #70

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
