### PR TITLE
feat: swagger-ui and api-info resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Verktyget tar en API-definition som indata och genererar en RDF-fil redo för sk
   - [Bakgrund](#bakgrund)
   - [Instruktioner för att komma igång snabbt](#instruktioner-för-att-komma-igång-snabbt)
   - [Användning](#användning)
+  - [API-dokumentation](#api-dokumentation)
   - [Systemkomponenter](#systemkomponenter)
   - [Lägga till stöd för nya metadata i verktyget](#lägga-till-stöd-för-nya-metadata-i-verktyget)
   - [Arbetsprocess för att publicera api/er på dataportalen](#arbetsprocess-för-att-publicera-apier-på-dataportalen)
@@ -151,6 +152,43 @@ Konvertera en katalog med specifikationsfiler och få DCAT-data till stdout:
 ```text
 java -jar dcat-ap-processor-0.0.3-SNAPSHOT.jar -d KATALOG
 ```
+
+## API-dokumentation
+
+Applikationen exponerar två endpoints för dokumentation och metadata om sitt API.
+
+### Swagger UI
+
+Interaktiv dokumentation för samtliga endpoints, inklusive parametrar,
+svarsformat och möjlighet att anropa API:et direkt från webbläsaren.
+
+```text
+https://<host>/swagger-ui
+```
+
+Den underliggande OpenAPI-specifikationen finns på `/openapi.yaml`
+
+### api-info
+
+Metadata om API:et
+
+```text
+GET https://<host>/api-info
+```
+
+```json
+{
+  "apiName": "DCAT-AP-SE Processor API",
+  "apiVersion": "0.1.0",
+  "apiReleased": "2026-08-06",
+  "apiDocumentation": "https://<host>/api-docs",
+  "apiStatus": "beta"
+}
+```
+
+`apiDocumentation` pekar som standard på den svarande instansens egen Swagger UI.
+Hostas verktyget bakom en gateway eller med publik dokumentation på annan plats
+kan länken sättas via `api-info.documentation` i `application.properties`.
 
 ## Systemkomponenter
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
 		    <scope>test</scope>
 		</dependency>
 		<dependency>
+  			<groupId>org.springdoc</groupId>
+  			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+  			<version>3.1.0</version>
+		</dependency>
+		<dependency>
 		    <groupId>org.commonmark</groupId>
 		    <artifactId>commonmark</artifactId>
 		    <version>0.22.0</version>

--- a/src/main/java/se/ams/dcatprocessor/controller/ApiInfoController.java
+++ b/src/main/java/se/ams/dcatprocessor/controller/ApiInfoController.java
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2022 Agency for Digital Government
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.ams.dcatprocessor.controller;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+@RestController
+class ApiInfoController {
+
+    private final Map<String, String> apiInfo;
+    private final String documentation;
+    private final String swaggerUiPath;
+
+    ApiInfoController(
+            @Value("classpath:static/openapi.yaml") Resource specification,
+            @Value("${api-info.documentation:}") String documentation,
+            @Value("${springdoc.swagger-ui.path:/api-docs}") String swaggerUiPath) throws IOException {
+        this.apiInfo = readAPIInfoFacts(specification);
+        this.documentation = documentation;
+        this.swaggerUiPath = swaggerUiPath;
+    }
+
+    @GetMapping(path = "/api-info", produces = MediaType.APPLICATION_JSON_VALUE)
+    Map<String, String> apiInfo() {
+        Map<String, String> response = new LinkedHashMap<>(apiInfo);
+        response.put("apiDocumentation", resolveDocumentationUrl());
+        return response;
+    }
+
+    private static Map<String, String> readAPIInfoFacts(Resource specification) throws IOException {
+        JsonNode info = new ObjectMapper(new YAMLFactory())
+            .readTree(specification.getInputStream())
+            .get("info");
+
+        return Map.of(
+            "apiName", info.get("title").asText(),
+            "apiVersion", info.get("version").asText(),
+            "apiReleased", info.get("x-api-released").asText(),
+            "apiStatus", info.get("x-api-status").asText());
+    }
+
+    /**
+     * The tool is self-hosted, so there is no official documentation URL. Falls back to
+     * the responding instance's Swagger UI unless api-info.documentation is configured.
+     */
+    private String resolveDocumentationUrl() {
+        if (StringUtils.hasText(documentation)) {
+            return documentation;
+        }
+        return ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path(swaggerUiPath)
+                .toUriString();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,13 @@ dcat.specification.properties=dcat_specification.properties
 # Health metrics
 management.endpoints.web.exposure.include=health,prometheus
 management.metrics.tags.application=${spring.application.name}
+
+# api-info
+# Name, version, release date and status live in static/openapi.yaml.
+# Documentation URL is derived from the incoming request when left empty.
+api-info.documentation=
+
+# swagger
+springdoc.swagger-ui.path=/swagger-ui
+springdoc.swagger-ui.url=/openapi.yaml
+springdoc.swagger-ui.disable-swagger-default-url=true

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1,0 +1,96 @@
+openapi: 3.1.0
+info:
+  title: DCAT-AP-SE Processor API
+  version: 0.1.0
+  x-api-released: '2022-10-01'
+  x-api-status: beta
+  summary: Converts API specifications into DCAT-AP-SE RDF/XML.
+  description: |
+    A tool for automating the production of metadata according to the
+    [DCAT-AP-SE](https://docs.dataportal.se/dcat/en/) metadata specification,
+    used to publish information about datasets and APIs on
+    [Sveriges dataportal](https://www.dataportal.se/)
+    The processor takes an API definition as input and generates an RDF file
+    ready to be harvested by Sveriges dataportal
+
+    ### Supported input
+    - **OpenAPI** in JSON format, OAS2 and OAS3
+    - **YAML/RAML** — 0.8 and 1.0
+    - **Standalone metadata files** JSON/RAML/YAML for APIs without a formal definition
+
+    ### Output
+    RDF/XML conforming to the DCAT-AP-SE specification
+
+    ### Usage
+    Designed to be integrated into a CI/CD pipeline or run standalone, so that
+    metadata stays in sync with the API definition it describes.
+  license:
+    name: EUPL-1.2
+    url: https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+externalDocs:
+  description: DCAT-AP-SE-processor repository
+  url: https://github.com/diggsweden/DCAT-AP-SE-Processor
+paths:
+  /dcat-generation/files/:
+    get:
+      tags:
+        - generation
+      operationId: generateRdfFromDirectory
+      summary: Generate DCAT-AP-SE metadata from a directory.
+      description: |
+        Reads every API specification in the given directory and returns the
+        resulting DCAT-AP-SE metadata as RDF/XML.
+
+        The directory is resolved on the server running the processor, not on the client.
+      parameters:
+        - name: dir
+          in: query
+          required: false
+          description: Server-side directory containing the API specifications to process.
+          schema:
+            type: string
+            default: /apidef
+      responses:
+        "200":
+          description: RDF/XML was generated, or a processing error message was returned.
+          content:
+            text/plain;charset=UTF-8:
+              schema:
+                type: string
+  /api-info:
+    get:
+      tags:
+        - metadata
+      operationId: getApiInfo
+      summary: Get API information.
+      description: Returns name, semantic version, release date, documentation URL and lifecycle status.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiInfo"
+              examples:
+                default:
+                  value:
+                    apiName: DCAT-AP-SE Processor API
+                    apiVersion: 0.1.0
+                    apiReleased: '2026-08-06'
+                    apiDocumentation: https://example.org/swagger-ui
+                    apiStatus: beta
+components:
+  schemas:
+    ApiInfo:
+      type: object
+      properties:
+        apiName:
+          type: string
+        apiVersion:
+          type: string
+        apiReleased:
+          type: string
+        apiDocumentation:
+          type: string
+        apiStatus:
+          type: string

--- a/src/test/java/se/ams/dcatprocessor/controller/ApiInfoControllerRestTest.java
+++ b/src/test/java/se/ams/dcatprocessor/controller/ApiInfoControllerRestTest.java
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2022 Agency for Digital Government
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.ams.dcatprocessor.controller;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@AutoConfigureTestRestTemplate
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class ApiInfoControllerRestTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private Map<String, String> apiInfo;
+
+    @BeforeEach
+    void fetchApiInfo() {
+        ResponseEntity<Map<String, String>> response = restTemplate.exchange(
+            "/api-info",
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<>() {});
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        apiInfo = response.getBody();
+        assertNotNull(apiInfo);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "apiName", 
+        "apiVersion", 
+        "apiReleased", 
+        "apiDocumentation", 
+        "apiStatus"
+    })
+    void testThatAttributeIsPresentAndNotBlank(String attribute) {
+        assertNotNull(apiInfo.get(attribute), attribute + " is missing");
+        assertFalse(apiInfo.get(attribute).isBlank(), attribute + " is blank");
+    }
+
+    @Test
+    void testThatApiReleasedIsAnIsoDate() {
+        assertDoesNotThrow(() -> LocalDate.parse(apiInfo.get("apiReleased")));
+    }
+
+    @Test
+    void testThatApiStatusIsAKnownLifecycleState() {
+        assertTrue(Set.of("beta", "active", "deprecated").contains(apiInfo.get("apiStatus")));
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds swagger-ui and a api-info endpoint to the application.

### Changes
- add Swagger UI served from OpenAPI specification at /openapi.yaml.
- add /api-info resource exposing API name, version, release date, documentation URL and lifecycle status.
- contract facts are read from openapi.yaml rather than duplicated in configuration.
- the documentation URL defaults to the responding instance's Swagger UI, and can be overridden with api-info.documentation.
- integration test for the new controller.
- documentation of feature in readme.

Fixes #65

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
