### PR TITLE
fix: ignore workflow files from OpenGrep scanning

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2022 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# TODO: OpenGrep SAST in pr-checks fail because .github/workflows/* uses secrets: inherit.
+# These workflows are owned by diggsweden/reusable-ci. Remove this ignore when upstream stops requiring it.
+.github/workflows/pullrequest-workflow.yml
+.github/workflows/release-workflow-dev.yml
+.github/workflows/release-workflow.yml


### PR DESCRIPTION
## Description

OpenGrep scanning finds faults in the Pull Request Workflows, and fails pipeline with error:

```
    .github/workflows/pullrequest-workflow.yml
   ❯❯❱ yaml.github-actions.security.secrets-inherit.secrets-inherit
          This workflow uses `secrets: inherit` to pass all of the calling workflow's secrets to a reusable   
          workflow. This violates the principle of least privilege...

           25┆ secrets: inherit # Pass org-level secrets (for private Maven dependencies)
                                              
    .github/workflows/release-workflow-dev.yml
   ❯❯❱ yaml.github-actions.security.secrets-inherit.secrets-inherit
          This workflow uses `secrets: inherit` to pass all of the calling workflow's secrets to a reusable   
          workflow. This violates the principle of least privilege...               
                                                                                                              
           33┆ secrets: inherit
```

The workflow files are currently using` secrets: inherit` by design and are owned by diggsweden/reusable-ci. This PR configures OpenGrep to ignore workflow files. When workflows have been updated and no longer uses `secrets: inherit` they should be removed from the .semgrepignore.

### Changes
- add ignore file for OpenGrep, ignoring workflowfiles with `secrets: inherit`